### PR TITLE
DEEP-230: Workaround for MongoTemplate app start up error

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongoconnection/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongoconnection/MongoConfig.java
@@ -3,7 +3,10 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongoconnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
@@ -25,5 +28,17 @@ class MongoConfig {
     public DateTimeProvider dateTimeProvider() {
         return () -> Optional.of(LocalDateTime.now());
     }
+
+    // TODO DEEP-230 START temporary code to prevent error on app start up
+    @Bean
+    MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoDatabaseFactory());
+    }
+
+    @Bean
+    MongoDatabaseFactory mongoDatabaseFactory() {
+        return new SimpleMongoClientDatabaseFactory("mongodb://localhost:27017/notifications");
+    }
+    // TODO DEEP-230 END temporary code to prevent error on app start up
 
 }


### PR DESCRIPTION
__DEEP-230__

* Temporary code to workaround a MongoTemplate dependency error preventing app start up.

### Type of change

* [X] Bug fix/workaround
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__