### PR TITLE
bau: add api key purely for testing

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,5 +40,5 @@ signin.url=${CHS_URL}/signin
 
 email.producer.appId=chs-gov-uk-notify-integration-api
 
-gov.uk.notify.api.key=${GOV_UK_NOTIFY_API_KEY:test2-3915518b-c71a-497b-8951-724b06c38418-bbfb9d07-b118-44d3-a438-7e7290f0bb9a}
+gov.uk.notify.api.key=${GOV_UK_NOTIFY_API_KEY:invalidatesoon-904c6f74-f758-4a25-a83a-dcfbdea4452f-81f9c7c2-cca8-4852-b1b6-f2ee69c1ebaf}
 


### PR DESCRIPTION
- will be invalidated soon after we're done testing
- eventually we'll put a proper long lived key in aws vault or something