### PR TITLE
refactor(bau): change healthcheck url

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/config/SecurityConfig.java
@@ -24,8 +24,6 @@ public class SecurityConfig {
             .authorizeHttpRequests(request -> request
                 .requestMatchers(GET, "/gov-uk-notify-integration/**")
                 .permitAll()
-                .requestMatchers(GET, "/healthcheck")
-                .permitAll()
                 .requestMatchers(POST, "/gov-uk-notify-integration/**")
                 .permitAll()
                 .anyRequest()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.data.mongodb.auto-index-creation=true
 # Actuator health check config
 management.endpoint.health.show-details=always
 management.endpoints.web.base-path=/
-management.endpoints.web.path-mapping.health=/healthcheck
+management.endpoints.web.path-mapping.health=/gov-uk-notify-integration/healthcheck
 management.endpoint.health.enabled=true
 
 #

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,8 +7,8 @@ locals {
   container_port             = "8080" # default Java port to match start script
   docker_repo                = "chs-gov-uk-notify-integration-api"
   lb_listener_rule_priority  = 18
-  lb_listener_paths          = ["/gov-uk-notify-integration/letter", "/gov-uk-notify-integration/email", "/healthcheck"]
-  healthcheck_path           = "/healthcheck" #healthcheck path for gov-uk-notify-integration service
+  lb_listener_paths          = ["/gov-uk-notify-integration/letter", "/gov-uk-notify-integration/email", "/gov-uk-notify-integration/healthcheck"]
+  healthcheck_path           = "/gov-uk-notify-integration/healthcheck" #healthcheck path for gov-uk-notify-integration service
   healthcheck_matcher        = "200"
   application_subnet_ids     = data.aws_subnets.application.ids
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"


### PR DESCRIPTION
- fix healthcheck url, we were mapping to /healthcheck which was the root of phoenix
- we want a healthcheck only for our service, so we need the prefix