### PR TITLE
Rename GOV_UK_NOTIFY_API_KEY to match AWS parameter store name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Sign up to [GovUK Notify](https://www.notifications.service.gov.uk/) or get a AP
 
 Set environment variables for GovUK Notify integration:
 ```bash
-export GOV_UK_NOTIFY_API_KEY=your_api_key_here
+export CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY=your_api_key_here
 ```
 
 ### Running the Application

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,15 @@
 spring.application.name=chs-gov-uk-notify-integration-api
 
-# debug=true
-
 # TODO DEEP-40 Remove the defaulting of the MONGODB_URL value, or replace localhost with mongo for docker.
 spring.data.mongodb.uri=${MONGODB_URL:mongodb://localhost:27017}
 spring.data.mongodb.database=${MONGODB_DATABASE:notification}
-
 spring.data.mongodb.auto-index-creation=true
 
 # Actuator health check config
 management.endpoint.health.show-details=always
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=/gov-uk-notify-integration/healthcheck
-management.endpoint.health.enabled=true
+management.endpoint.health.access=read_only
 
 #
 # these can be useful for local debugging
@@ -39,6 +36,5 @@ api.url=${API_URL}
 signin.url=${CHS_URL}/signin
 
 email.producer.appId=chs-gov-uk-notify-integration-api
-
-gov.uk.notify.api.key=${GOV_UK_NOTIFY_API_KEY:invalidatesoon-904c6f74-f758-4a25-a83a-dcfbdea4452f-81f9c7c2-cca8-4852-b1b6-f2ee69c1ebaf}
+gov.uk.notify.api.key=${CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY}
 

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("integration-test")
-@SpringBootTest("gov.uk.notify.api.key=${GOV_UK_NOTIFY_API_KEY}")
+@SpringBootTest("gov.uk.notify.api.key=${CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY}")
 @AutoConfigureMockMvc
 @ExtendWith({SystemStubsExtension.class, OutputCaptureExtension.class})
 class SenderRestApiIntegrationTest extends AbstractMongoDBTest {
@@ -51,7 +51,7 @@ class SenderRestApiIntegrationTest extends AbstractMongoDBTest {
     @BeforeAll
     static void setup() {
         // Given
-        variables.set("GOV_UK_NOTIFY_API_KEY", "Token value");
+        variables.set("CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY", "Token value");
     }
 
     @Test


### PR DESCRIPTION
Change environment variable to CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY to align with the existing name in our AWS parameter store.

- Modifying test class SenderRestApiIntegrationTest.java
- Removing default value from application.properties
- Updating documentation in README.md
- Setting health endpoint access to read_only
- Cleaning up properties file formatting

