### PR TITLE
Feature/deep 321 add creation and modification timestamps to notify integration api mongo db documents

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
@@ -11,7 +10,6 @@ import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest
 import java.time.LocalDateTime;
 
 @Document(collection = "email_details")
-@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailRequest {
     @Field("created_at") @CreatedDate
     private LocalDateTime createdAt;
@@ -73,10 +71,8 @@ public class NotificationEmailRequest {
                 "createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 ", request=" + request +
-                ", Id='" + id + '\'' +
+                ", id='" + id + '\'' +
                 '}';
     }
-
-
 }
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest
 
 import java.time.LocalDateTime;
 
+@Document(collection = "requests")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailRequest {
     @Field("created_at") @CreatedDate
@@ -18,8 +19,10 @@ public class NotificationEmailRequest {
     @Field("updated_at") @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Field("request")
     private GovUkEmailDetailsRequest request;
 
+    @Id
     private String id;
 
     public NotificationEmailRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkEmailDetailsRequest request, String id) {
@@ -27,6 +30,9 @@ public class NotificationEmailRequest {
         this.updatedAt = updatedAt;
         this.request = request;
         this.id = id;
+    }
+
+    public NotificationEmailRequest() {
     }
 
     public GovUkEmailDetailsRequest getRequest() {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -20,13 +20,13 @@ public class NotificationEmailRequest {
 
     private GovUkEmailDetailsRequest request;
 
-    private String Id;
+    private String id;
 
     public NotificationEmailRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkEmailDetailsRequest request, String id) {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.request = request;
-        Id = id;
+        this.id = id;
     }
 
     public GovUkEmailDetailsRequest getRequest() {
@@ -34,7 +34,7 @@ public class NotificationEmailRequest {
     }
 
     public String getId() {
-        return Id;
+        return id;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -50,7 +50,7 @@ public class NotificationEmailRequest {
     }
 
     public void setId(String id) {
-        Id = id;
+        id = id;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {
@@ -67,7 +67,7 @@ public class NotificationEmailRequest {
                 "createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 ", request=" + request +
-                ", Id='" + Id + '\'' +
+                ", Id='" + id + '\'' +
                 '}';
     }
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -56,7 +56,7 @@ public class NotificationEmailRequest {
     }
 
     public void setId(String id) {
-        id = id;
+        this.id = id;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -1,14 +1,76 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 
-@Document(collection = "email_details")
-public record NotificationEmailRequest(
-        @Id String id,
-        @Field("request") GovUkEmailDetailsRequest request
-) {
-    // Empty: using only auto-generated methods
+import java.time.LocalDateTime;
+
+@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
+public class NotificationEmailRequest {
+    @Field("created_at") @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Field("updated_at") @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private GovUkEmailDetailsRequest request;
+
+    private String Id;
+
+    public NotificationEmailRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkEmailDetailsRequest request, String id) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.request = request;
+        Id = id;
+    }
+
+    public GovUkEmailDetailsRequest getRequest() {
+        return request;
+    }
+
+    public String getId() {
+        return Id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setRequest(GovUkEmailDetailsRequest request) {
+        this.request = request;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationEmailRequest{" +
+                "createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", request=" + request +
+                ", Id='" + Id + '\'' +
+                '}';
+    }
+
+
 }
+

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailRequest.java
@@ -10,7 +10,7 @@ import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest
 
 import java.time.LocalDateTime;
 
-@Document(collection = "requests")
+@Document(collection = "email_details")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailRequest {
     @Field("created_at") @CreatedDate

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -8,7 +9,7 @@ import uk.gov.service.notify.SendEmailResponse;
 
 import java.time.LocalDateTime;
 
-
+//@Document(collection = "responses")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailResponse {
 
@@ -18,8 +19,10 @@ public class NotificationEmailResponse {
     @Field("updated_at") @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Field("response")
     private SendEmailResponse response;
 
+    @Id
     private String id;
 
     public NotificationEmailResponse(LocalDateTime createdAt, LocalDateTime updatedAt, SendEmailResponse response, String id) {
@@ -27,6 +30,9 @@ public class NotificationEmailResponse {
         this.updatedAt = updatedAt;
         this.response = response;
         this.id = id;
+    }
+
+    public NotificationEmailResponse() {
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
@@ -1,12 +1,9 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.service.notify.SendEmailResponse;
 
 import java.time.LocalDateTime;
@@ -23,13 +20,13 @@ public class NotificationEmailResponse {
 
     private SendEmailResponse response;
 
-    private String Id;
+    private String id;
 
     public NotificationEmailResponse(LocalDateTime createdAt, LocalDateTime updatedAt, SendEmailResponse response, String id) {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.response = response;
-        Id = id;
+        this.id = id;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -57,11 +54,11 @@ public class NotificationEmailResponse {
     }
 
     public String getId() {
-        return Id;
+        return id;
     }
 
     public void setId(String id) {
-        Id = id;
+        this.id = id;
     }
 
     @Override
@@ -70,7 +67,7 @@ public class NotificationEmailResponse {
                 "createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 ", response=" + response +
-                ", Id='" + Id + '\'' +
+                ", Id='" + id + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.service.notify.SendEmailResponse;
@@ -11,7 +10,6 @@ import uk.gov.service.notify.SendEmailResponse;
 import java.time.LocalDateTime;
 
 @Document(collection = "responses")
-@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailResponse {
 
     @Field("created_at") @CreatedDate

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
@@ -1,16 +1,77 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.service.notify.SendEmailResponse;
 
+import java.time.LocalDateTime;
 
-@Document(collection = "responses")
-public record NotificationEmailResponse(
-        @Id String id,
-        @Field("response") SendEmailResponse response
-) {
-    // Empty: using only auto-generated methods
+
+@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
+public class NotificationEmailResponse {
+
+    @Field("created_at") @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Field("updated_at") @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private SendEmailResponse response;
+
+    private String Id;
+
+    public NotificationEmailResponse(LocalDateTime createdAt, LocalDateTime updatedAt, SendEmailResponse response, String id) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.response = response;
+        Id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public SendEmailResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(SendEmailResponse response) {
+        this.response = response;
+    }
+
+    public String getId() {
+        return Id;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationEmailResponse{" +
+                "createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", response=" + response +
+                ", Id='" + Id + '\'' +
+                '}';
+    }
 }
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationEmailResponse.java
@@ -4,12 +4,13 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.service.notify.SendEmailResponse;
 
 import java.time.LocalDateTime;
 
-//@Document(collection = "responses")
+@Document(collection = "responses")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationEmailResponse {
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
@@ -3,11 +3,13 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
 
 import java.time.LocalDateTime;
 
+@Document(collection = "letter_details")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationLetterRequest {
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
@@ -1,13 +1,10 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
-import uk.gov.service.notify.SendEmailResponse;
 
 import java.time.LocalDateTime;
 
@@ -29,6 +26,9 @@ public class NotificationLetterRequest {
         this.updatedAt = updatedAt;
         this.request = request;
         this.id = id;
+    }
+
+    public NotificationLetterRequest() {
     }
 
     public LocalDateTime getCreatedAt() {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
@@ -22,13 +22,13 @@ public class NotificationLetterRequest {
 
     private GovUkLetterDetailsRequest request;
 
-    private String Id;
+    private String id;
 
     public NotificationLetterRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkLetterDetailsRequest request, String id) {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.request = request;
-        Id = id;
+        this.id = id;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -56,11 +56,11 @@ public class NotificationLetterRequest {
     }
 
     public String getId() {
-        return Id;
+        return id;
     }
 
     public void setId(String id) {
-        Id = id;
+        this.id = id;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class NotificationLetterRequest {
                 "createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 ", request=" + request +
-                ", Id='" + Id + '\'' +
+                ", Id='" + id + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
@@ -1,14 +1,75 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
+import uk.gov.service.notify.SendEmailResponse;
 
-@Document(collection = "letter_details")
-public record NotificationLetterRequest(
-        @Id String id,
-        @Field("request") GovUkLetterDetailsRequest request
-) {
-    // Empty: using only auto-generated methods
+import java.time.LocalDateTime;
+
+@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
+public class NotificationLetterRequest {
+
+    @Field("created_at") @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Field("updated_at") @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private GovUkLetterDetailsRequest request;
+
+    private String Id;
+
+    public NotificationLetterRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkLetterDetailsRequest request, String id) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.request = request;
+        Id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public GovUkLetterDetailsRequest getRequest() {
+        return request;
+    }
+
+    public void setRequest(GovUkLetterDetailsRequest request) {
+        this.request = request;
+    }
+
+    public String getId() {
+        return Id;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationLetterRequest{" +
+                "createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", request=" + request +
+                ", Id='" + Id + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterRequest.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsReques
 import java.time.LocalDateTime;
 
 @Document(collection = "letter_details")
-@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationLetterRequest {
 
     @Field("created_at") @CreatedDate
@@ -19,8 +18,10 @@ public class NotificationLetterRequest {
     @Field("updated_at") @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Field("request")
     private GovUkLetterDetailsRequest request;
 
+    @Id
     private String id;
 
     public NotificationLetterRequest(LocalDateTime createdAt, LocalDateTime updatedAt, GovUkLetterDetailsRequest request, String id) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
@@ -1,16 +1,77 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
 import uk.gov.service.notify.LetterResponse;
 
+import java.time.LocalDateTime;
 
-@Document(collection = "responses")
-public record NotificationLetterResponse(
-        @Id String id,
-        @Field("response") LetterResponse response
-) {
-    // Empty: using only auto-generated methods
+
+@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
+public class NotificationLetterResponse {
+
+    @Field("created_at") @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Field("updated_at") @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LetterResponse response;
+
+    private String Id;
+
+    public NotificationLetterResponse(LocalDateTime createdAt, LocalDateTime updatedAt, LetterResponse response, String id) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.response = response;
+        Id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LetterResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(LetterResponse response) {
+        this.response = response;
+    }
+
+    public String getId() {
+        return Id;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationLetterResponse{" +
+                "createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", response=" + response +
+                ", Id='" + Id + '\'' +
+                '}';
+    }
 }
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
@@ -1,12 +1,9 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
 import uk.gov.service.notify.LetterResponse;
 
 import java.time.LocalDateTime;
@@ -23,13 +20,13 @@ public class NotificationLetterResponse {
 
     private LetterResponse response;
 
-    private String Id;
+    private String id;
 
     public NotificationLetterResponse(LocalDateTime createdAt, LocalDateTime updatedAt, LetterResponse response, String id) {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.response = response;
-        Id = id;
+        this.id = id;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -57,11 +54,11 @@ public class NotificationLetterResponse {
     }
 
     public String getId() {
-        return Id;
+        return id;
     }
 
     public void setId(String id) {
-        Id = id;
+        this.id = id;
     }
 
     @Override
@@ -70,7 +67,7 @@ public class NotificationLetterResponse {
                 "createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 ", response=" + response +
-                ", Id='" + Id + '\'' +
+                ", Id='" + id + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
@@ -29,6 +29,9 @@ public class NotificationLetterResponse {
         this.id = id;
     }
 
+    public NotificationLetterResponse() {
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.service.notify.LetterResponse;
@@ -10,7 +10,6 @@ import uk.gov.service.notify.LetterResponse;
 import java.time.LocalDateTime;
 
 @Document(collection = "responses")
-@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationLetterResponse {
 
     @Field("created_at") @CreatedDate
@@ -19,8 +18,10 @@ public class NotificationLetterResponse {
     @Field("updated_at") @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Field("response")
     private LetterResponse response;
 
+    @Id
     private String id;
 
     public NotificationLetterResponse(LocalDateTime createdAt, LocalDateTime updatedAt, LetterResponse response, String id) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationLetterResponse.java
@@ -3,12 +3,13 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.service.notify.LetterResponse;
 
 import java.time.LocalDateTime;
 
-
+@Document(collection = "responses")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationLetterResponse {
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
@@ -1,19 +1,112 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.document;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.service.notify.LetterResponse;
 
 
-@Document(collection = "status")
-public record NotificationStatus(
-        @Id String id,
-        @Field("requestId") String requestId,
-        @Field("responseId") String responseId,
-        @Field("status") String status,
-        @Field("statusDetails") Map<String, Object> statusDetails
-) {
-    // Empty: using only auto-generated methods
+@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
+public class NotificationStatus {
+
+    @Field("created_at") @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Field("updated_at") @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+     @Field("requestId") String requestId;
+
+     @Field("responseId") String responseId;
+
+     @Field("status") String status;
+
+     @Field("statusDetails") Map<String, Object> statusDetails;
+
+     private String Id;
+
+    public NotificationStatus(LocalDateTime createdAt, LocalDateTime updatedAt, String requestId, String responseId, String status, Map<String, Object> statusDetails, String id) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.requestId = requestId;
+        this.responseId = responseId;
+        this.status = status;
+        this.statusDetails = statusDetails;
+        Id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getResponseId() {
+        return responseId;
+    }
+
+    public void setResponseId(String responseId) {
+        this.responseId = responseId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Map<String, Object> getStatusDetails() {
+        return statusDetails;
+    }
+
+    public void setStatusDetails(Map<String, Object> statusDetails) {
+        this.statusDetails = statusDetails;
+    }
+
+    public String getId() {
+        return Id;
+    }
+
+    public void setId(String id) {
+        Id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationStatus{" +
+                "createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", requestId='" + requestId + '\'' +
+                ", responseId='" + responseId + '\'' +
+                ", status='" + status + '\'' +
+                ", statusDetails=" + statusDetails +
+                ", Id='" + Id + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
@@ -38,6 +38,9 @@ public class NotificationStatus {
         this.id = id;
     }
 
+    public NotificationStatus() {
+    }
+
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
@@ -4,12 +4,9 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.service.notify.LetterResponse;
 
 
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
@@ -29,7 +26,7 @@ public class NotificationStatus {
 
      @Field("statusDetails") Map<String, Object> statusDetails;
 
-     private String Id;
+     private String id;
 
     public NotificationStatus(LocalDateTime createdAt, LocalDateTime updatedAt, String requestId, String responseId, String status, Map<String, Object> statusDetails, String id) {
         this.createdAt = createdAt;
@@ -38,7 +35,7 @@ public class NotificationStatus {
         this.responseId = responseId;
         this.status = status;
         this.statusDetails = statusDetails;
-        Id = id;
+        this.id = id;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -90,11 +87,11 @@ public class NotificationStatus {
     }
 
     public String getId() {
-        return Id;
+        return id;
     }
 
     public void setId(String id) {
-        Id = id;
+        this.id = id;
     }
 
     @Override
@@ -106,7 +103,7 @@ public class NotificationStatus {
                 ", responseId='" + responseId + '\'' +
                 ", status='" + status + '\'' +
                 ", statusDetails=" + statusDetails +
-                ", Id='" + Id + '\'' +
+                ", Id='" + id + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
@@ -4,13 +4,12 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "status")
-@EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationStatus {
 
     @Field("created_at") @CreatedDate
@@ -19,15 +18,20 @@ public class NotificationStatus {
     @Field("updated_at") @LastModifiedDate
     private LocalDateTime updatedAt;
 
-     @Field("requestId") String requestId;
+    @Field("requestId")
+    private String requestId;
 
-     @Field("responseId") String responseId;
+    @Field("responseId")
+    private String responseId;
 
-     @Field("status") String status;
+    @Field("status")
+    private String status;
 
-     @Field("statusDetails") Map<String, Object> statusDetails;
+    @Field("statusDetails")
+    private Map<String, Object> statusDetails;
 
-     private String id;
+    @Id
+    private String id;
 
     public NotificationStatus(LocalDateTime createdAt, LocalDateTime updatedAt, String requestId, String responseId, String status, Map<String, Object> statusDetails, String id) {
         this.createdAt = createdAt;

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/document/NotificationStatus.java
@@ -6,9 +6,10 @@ import java.util.Map;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
-
+@Document(collection = "status")
 @EnableMongoAuditing(dateTimeProviderRef = "mongodbDatetimeProvider")
 public class NotificationStatus {
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.service;
 
-
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +43,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailRequest storeEmail(final GovUkEmailDetailsRequest emailDetailsRequest) {
-        return notificationEmailRequestRepository.save(new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailDetailsRequest, null));
+        return notificationEmailRequestRepository.save(new NotificationEmailRequest(null, null, emailDetailsRequest, null));
     }
 
     public Optional<NotificationEmailRequest> getEmail(final String id) {
@@ -61,7 +59,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationLetterRequest storeLetter(final GovUkLetterDetailsRequest letterDetails) {
-        return notificationLetterRequestRepository.save(new NotificationLetterRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterDetails, null));
+        return notificationLetterRequestRepository.save(new NotificationLetterRequest(null, null, letterDetails, null));
     }
 
     public Optional<NotificationLetterRequest> getLetter(final String letterId) {
@@ -77,11 +75,11 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailResponse storeResponse(final GovUkNotifyService.EmailResp emailResp) {
-        return notificationEmailResponseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailResp.response(), null));
+        return notificationEmailResponseRepository.save(new NotificationEmailResponse(null, null, emailResp.response(), null));
     }
 
     public NotificationLetterResponse storeResponse(final GovUkNotifyService.LetterResp letterResp) {
-        return notificationLetterResponseRepository.save(new NotificationLetterResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterResp.response(), null));
+        return notificationLetterResponseRepository.save(new NotificationLetterResponse(null, null, letterResp.response(), null));
     }
 
     public NotificationStatus updateStatus(final NotificationStatus notificationStatus) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
@@ -44,7 +44,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailRequest storeEmail(final GovUkEmailDetailsRequest emailDetailsRequest) {
-        return notificationEmailRequestRepository.save(new NotificationEmailRequest(null, emailDetailsRequest));
+        return notificationEmailRequestRepository.save(new NotificationEmailRequest(null, null, null, null));
     }
 
     public Optional<NotificationEmailRequest> getEmail(final String id) {
@@ -60,7 +60,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationLetterRequest storeLetter(final GovUkLetterDetailsRequest letterDetails) {
-        return notificationLetterRequestRepository.save(new NotificationLetterRequest(null, letterDetails));
+        return notificationLetterRequestRepository.save(new NotificationLetterRequest(null, null, null, null));
     }
 
     public Optional<NotificationLetterRequest> getLetter(final String letterId) {
@@ -76,11 +76,11 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailResponse storeResponse(final GovUkNotifyService.EmailResp emailResp) {
-        return notificationEmailResponseRepository.save(new NotificationEmailResponse(null, emailResp.response()));
+        return notificationEmailResponseRepository.save(new NotificationEmailResponse(null, null, null, null));
     }
 
     public NotificationLetterResponse storeResponse(final GovUkNotifyService.LetterResp letterResp) {
-        return notificationLetterResponseRepository.save(new NotificationLetterResponse(null, letterResp.response()));
+        return notificationLetterResponseRepository.save(new NotificationLetterResponse(null, null, null, null));
     }
 
     public NotificationStatus updateStatus(final NotificationStatus notificationStatus) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.service;
 
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +45,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailRequest storeEmail(final GovUkEmailDetailsRequest emailDetailsRequest) {
-        return notificationEmailRequestRepository.save(new NotificationEmailRequest(null, null, null, null));
+        return notificationEmailRequestRepository.save(new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailDetailsRequest, "1"));
     }
 
     public Optional<NotificationEmailRequest> getEmail(final String id) {
@@ -60,7 +61,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationLetterRequest storeLetter(final GovUkLetterDetailsRequest letterDetails) {
-        return notificationLetterRequestRepository.save(new NotificationLetterRequest(null, null, null, null));
+        return notificationLetterRequestRepository.save(new NotificationLetterRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterDetails, "1"));
     }
 
     public Optional<NotificationLetterRequest> getLetter(final String letterId) {
@@ -76,11 +77,11 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailResponse storeResponse(final GovUkNotifyService.EmailResp emailResp) {
-        return notificationEmailResponseRepository.save(new NotificationEmailResponse(null, null, null, null));
+        return notificationEmailResponseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailResp.response(), "1"));
     }
 
     public NotificationLetterResponse storeResponse(final GovUkNotifyService.LetterResp letterResp) {
-        return notificationLetterResponseRepository.save(new NotificationLetterResponse(null, null, null, null));
+        return notificationLetterResponseRepository.save(new NotificationLetterResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterResp.response(), "1"));
     }
 
     public NotificationStatus updateStatus(final NotificationStatus notificationStatus) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseService.java
@@ -45,7 +45,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailRequest storeEmail(final GovUkEmailDetailsRequest emailDetailsRequest) {
-        return notificationEmailRequestRepository.save(new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailDetailsRequest, "1"));
+        return notificationEmailRequestRepository.save(new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailDetailsRequest, null));
     }
 
     public Optional<NotificationEmailRequest> getEmail(final String id) {
@@ -61,7 +61,7 @@ public class NotificationDatabaseService {
     }
 
     public NotificationLetterRequest storeLetter(final GovUkLetterDetailsRequest letterDetails) {
-        return notificationLetterRequestRepository.save(new NotificationLetterRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterDetails, "1"));
+        return notificationLetterRequestRepository.save(new NotificationLetterRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterDetails, null));
     }
 
     public Optional<NotificationLetterRequest> getLetter(final String letterId) {
@@ -77,11 +77,11 @@ public class NotificationDatabaseService {
     }
 
     public NotificationEmailResponse storeResponse(final GovUkNotifyService.EmailResp emailResp) {
-        return notificationEmailResponseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailResp.response(), "1"));
+        return notificationEmailResponseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailResp.response(), null));
     }
 
     public NotificationLetterResponse storeResponse(final GovUkNotifyService.LetterResp letterResp) {
-        return notificationLetterResponseRepository.save(new NotificationLetterResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterResp.response(), "1"));
+        return notificationLetterResponseRepository.save(new NotificationLetterResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), letterResp.response(), null));
     }
 
     public NotificationStatus updateStatus(final NotificationStatus notificationStatus) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/ReaderRestApi.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/ReaderRestApi.java
@@ -44,7 +44,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         return new ResponseEntity<>(
                 emails.stream()
-                        .map(NotificationEmailRequest::request)
+                        .map(NotificationEmailRequest::getRequest)
                         .toList(),
                 HttpStatus.OK
         );
@@ -63,7 +63,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         if (emailRequest.isPresent()) {
             LOGGER.info("Email notification found with ID: " + id, logMap);
-            return new ResponseEntity<>(emailRequest.get().request(), HttpStatus.OK);
+            return new ResponseEntity<>(emailRequest.get().getRequest(), HttpStatus.OK);
         } else {
             LOGGER.info("Email notification not found with ID: " + id, logMap);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -86,7 +86,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         return new ResponseEntity<>(
                 emails.stream()
-                        .map(NotificationEmailRequest::request)
+                        .map(NotificationEmailRequest::getRequest)
                         .toList(),
                 HttpStatus.OK
         );
@@ -106,7 +106,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         return new ResponseEntity<>(
                 letters.stream()
-                        .map(NotificationLetterRequest::request)
+                        .map(NotificationLetterRequest::getRequest)
                         .toList(),
                 HttpStatus.OK
         );
@@ -126,7 +126,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         if (letterRequest.isPresent()) {
             LOGGER.info("Letter notification found with ID: " + id, logMap);
-            return new ResponseEntity<>(letterRequest.get().request(), HttpStatus.OK);
+            return new ResponseEntity<>(letterRequest.get().getRequest(), HttpStatus.OK);
         } else {
             LOGGER.info("Letter notification not found with ID: " + id, logMap);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -149,7 +149,7 @@ public class ReaderRestApi implements NotifyIntegrationRetrieverControllerInterf
 
         return new ResponseEntity<>(
                 letters.stream()
-                        .map(NotificationLetterRequest::request)
+                        .map(NotificationLetterRequest::getRequest)
                         .toList(),
                 HttpStatus.OK
         );

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -95,7 +94,7 @@ public class TestUtils {
                 .emailDetails(emailDetails)
                 .createdAt(OffsetDateTime.now());
 
-        return new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailRequest, "1");
+        return new NotificationEmailRequest(null, null, emailRequest, "1");
     }
 
     public static SendEmailResponse createSampleEmailResponse() {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ public class TestUtils {
                 .emailDetails(emailDetails)
                 .createdAt(OffsetDateTime.now());
 
-        return new NotificationEmailRequest(null, null, null, null);
+        return new NotificationEmailRequest(LocalDateTime.now(), LocalDateTime.now().plusHours(1), emailRequest, "1");
     }
 
     public static SendEmailResponse createSampleEmailResponse() {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/TestUtils.java
@@ -94,7 +94,7 @@ public class TestUtils {
                 .emailDetails(emailDetails)
                 .createdAt(OffsetDateTime.now());
 
-        return new NotificationEmailRequest(null, emailRequest);
+        return new NotificationEmailRequest(null, null, null, null);
     }
 
     public static SendEmailResponse createSampleEmailResponse() {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
@@ -29,6 +29,8 @@ class NotificationEmailRequestRepositoryTest extends AbstractMongoDBTest {
 
         assertNotNull(savedRequest);
         assertNotNull(savedRequest.getId());
+        assertNotNull(savedRequest.getCreatedAt());
+        assertNotNull(savedRequest.getUpdatedAt());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
@@ -25,29 +25,29 @@ class NotificationEmailRequestRepositoryTest extends AbstractMongoDBTest {
     @Test
     void When_NewRequestSaved_Expect_IdAssigned() {
         GovUkEmailDetailsRequest emailRequest = createSampleEmailRequest("john.doe@example.com");
-        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, emailRequest));
+        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, null, emailRequest, null));
 
         assertNotNull(savedRequest);
-        assertNotNull(savedRequest.id());
+        assertNotNull(savedRequest.getId());
     }
 
     @Test
     void When_RequestSaved_Expect_DataCanBeRetrievedById() {
         GovUkEmailDetailsRequest emailRequest = createSampleEmailRequest("jane.doe@example.com");
-        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, emailRequest));
+        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, null, emailRequest, null));
 
-        Optional<NotificationEmailRequest> retrievedRequest = requestRepository.findById(savedRequest.id());
+        Optional<NotificationEmailRequest> retrievedRequest = requestRepository.findById(savedRequest.getId());
 
         assertTrue(retrievedRequest.isPresent());
-        assertEquals(savedRequest.id(), retrievedRequest.get().id());
-        assertEquals("jane.doe@example.com", retrievedRequest.get().request().getRecipientDetails().getEmailAddress());
+        assertEquals(savedRequest.getId(), retrievedRequest.get().getId());
+        assertEquals("jane.doe@example.com", retrievedRequest.get().getRequest().getRecipientDetails().getEmailAddress());
     }
 
     @Test
     void When_MultipleRequestsSaved_Expect_AllCanBeRetrieved() {
-        requestRepository.save(new NotificationEmailRequest(null, createSampleEmailRequest("user1@example.com")));
-        requestRepository.save(new NotificationEmailRequest(null, createSampleEmailRequest("user2@example.com")));
-        requestRepository.save(new NotificationEmailRequest(null, createSampleEmailRequest("user3@example.com")));
+        requestRepository.save(new NotificationEmailRequest(null, null, createSampleEmailRequest("user1@example.com"), null));
+        requestRepository.save(new NotificationEmailRequest(null, null, createSampleEmailRequest("user2@example.com"), null));
+        requestRepository.save(new NotificationEmailRequest(null, null, createSampleEmailRequest("user3@example.com"), null));
 
         List<NotificationEmailRequest> allRequests = requestRepository.findAll();
 
@@ -56,26 +56,26 @@ class NotificationEmailRequestRepositoryTest extends AbstractMongoDBTest {
 
     @Test
     void When_RequestDeleted_Expect_RequestNotFoundById() {
-        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, createSampleEmailRequest("test@example.com")));
+        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, null, createSampleEmailRequest("test@example.com"), null));
 
-        requestRepository.deleteById(savedRequest.id());
+        requestRepository.deleteById(savedRequest.getId());
 
-        Optional<NotificationEmailRequest> deletedRequest = requestRepository.findById(savedRequest.id());
+        Optional<NotificationEmailRequest> deletedRequest = requestRepository.findById(savedRequest.getId());
         assertFalse(deletedRequest.isPresent());
     }
 
     @Test
     void When_RequestUpdated_Expect_ChangesReflectedInDatabase() {
         GovUkEmailDetailsRequest initialRequest = createSampleEmailRequest("initial@example.com");
-        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, initialRequest));
+        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, null, initialRequest, null));
 
         GovUkEmailDetailsRequest updatedRequest = createSampleEmailRequest("updated@example.com");
-        requestRepository.save(new NotificationEmailRequest(savedRequest.id(), updatedRequest));
+        requestRepository.save(new NotificationEmailRequest(null, null, updatedRequest, savedRequest.getId()));
 
-        NotificationEmailRequest retrievedRequest = requestRepository.findById(savedRequest.id()).orElse(null);
+        NotificationEmailRequest retrievedRequest = requestRepository.findById(savedRequest.getId()).orElse(null);
 
         assertNotNull(retrievedRequest);
-        assertEquals("updated@example.com", retrievedRequest.request().getRecipientDetails().getEmailAddress());
+        assertEquals("updated@example.com", retrievedRequest.getRequest().getRecipientDetails().getEmailAddress());
     }
     
 }

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailRequestRepositoryTest.java
@@ -25,9 +25,14 @@ class NotificationEmailRequestRepositoryTest extends AbstractMongoDBTest {
     @Test
     void When_NewRequestSaved_Expect_IdAssigned() {
         GovUkEmailDetailsRequest emailRequest = createSampleEmailRequest("john.doe@example.com");
-        NotificationEmailRequest savedRequest = requestRepository.save(new NotificationEmailRequest(null, null, emailRequest, null));
+        NotificationEmailRequest notificationEmailRequest = new NotificationEmailRequest();
+        notificationEmailRequest.setRequest(emailRequest);
+        notificationEmailRequest.setId(null);
+        notificationEmailRequest.setCreatedAt(null);
+        notificationEmailRequest.setUpdatedAt(null);
+        NotificationEmailRequest savedRequest = requestRepository.save(notificationEmailRequest);
 
-        assertNotNull(savedRequest);
+        assertNotNull(savedRequest.toString());
         assertNotNull(savedRequest.getId());
         assertNotNull(savedRequest.getCreatedAt());
         assertNotNull(savedRequest.getUpdatedAt());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
@@ -26,10 +26,15 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
     void When_NewResponseSaved_Expect_IdAssigned() {
         SendEmailResponse emailResponse = createSampleEmailResponse(UUID.randomUUID(), UUID.randomUUID());
 
+        NotificationEmailResponse notificationEmailResponse = new NotificationEmailResponse();
+        notificationEmailResponse.setCreatedAt(null);
+        notificationEmailResponse.setUpdatedAt(null);
+        notificationEmailResponse.setResponse(emailResponse);
+        notificationEmailResponse.setId(null);
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, null, null, null));
+                notificationEmailResponse);
 
-        assertNotNull(savedResponse);
+        assertNotNull(savedResponse.toString());
         assertNotNull(savedResponse.getId());
         assertNotNull(savedResponse.getCreatedAt());
         assertNotNull(savedResponse.getUpdatedAt());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,7 +40,7 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         SendEmailResponse emailResponse = createSampleEmailResponse(UUID.randomUUID(), notificationId);
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, null, null, null));
+                new NotificationEmailResponse(null, null, emailResponse, "1"));
 
         Optional<NotificationEmailResponse> retrievedResponse = responseRepository.findById(savedResponse.getId());
 
@@ -66,9 +67,9 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         UUID updatedNotificationId = UUID.randomUUID();
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),initialNotificationId), null));
+                new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), createSampleEmailResponse(UUID.randomUUID(),initialNotificationId), "1"));
 
-        responseRepository.save(new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),updatedNotificationId), savedResponse.getId()));
+        responseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), createSampleEmailResponse(UUID.randomUUID(),updatedNotificationId), savedResponse.getId()));
 
         NotificationEmailResponse retrievedResponse = responseRepository.findById(savedResponse.getId()).orElse(null);
 

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
@@ -27,10 +27,10 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         SendEmailResponse emailResponse = createSampleEmailResponse(UUID.randomUUID(), UUID.randomUUID());
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, emailResponse));
+                new NotificationEmailResponse(null, null, null, null));
 
         assertNotNull(savedResponse);
-        assertNotNull(savedResponse.id());
+        assertNotNull(savedResponse.getId());
     }
 
     @Test
@@ -39,24 +39,24 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         SendEmailResponse emailResponse = createSampleEmailResponse(UUID.randomUUID(), notificationId);
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, emailResponse));
+                new NotificationEmailResponse(null, null, null, null));
 
-        Optional<NotificationEmailResponse> retrievedResponse = responseRepository.findById(savedResponse.id());
+        Optional<NotificationEmailResponse> retrievedResponse = responseRepository.findById(savedResponse.getId());
 
         assertTrue(retrievedResponse.isPresent());
-        assertEquals(savedResponse.id(), retrievedResponse.get().id());
-        assertEquals(notificationId, retrievedResponse.get().response().getNotificationId());
+        assertEquals(savedResponse.getId(), retrievedResponse.get().getId());
+        assertEquals(notificationId, retrievedResponse.get().getResponse().getNotificationId());
     }
 
 
     @Test
     void When_ResponseDeleted_Expect_ResponseNotFoundById() {
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, createSampleEmailResponse(UUID.randomUUID(), UUID.randomUUID())));
+                new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),UUID.randomUUID()), null ));
 
-        responseRepository.deleteById(savedResponse.id());
+        responseRepository.deleteById(savedResponse.getId());
 
-        Optional<NotificationEmailResponse> deletedResponse = responseRepository.findById(savedResponse.id());
+        Optional<NotificationEmailResponse> deletedResponse = responseRepository.findById(savedResponse.getId());
         assertFalse(deletedResponse.isPresent());
     }
 
@@ -66,15 +66,14 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         UUID updatedNotificationId = UUID.randomUUID();
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, createSampleEmailResponse(UUID.randomUUID(), initialNotificationId)));
+                new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),initialNotificationId), null));
 
-        responseRepository.save(new NotificationEmailResponse(savedResponse.id(),
-                createSampleEmailResponse(UUID.randomUUID(), updatedNotificationId)));
+        responseRepository.save(new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),updatedNotificationId), savedResponse.getId()));
 
-        NotificationEmailResponse retrievedResponse = responseRepository.findById(savedResponse.id()).orElse(null);
+        NotificationEmailResponse retrievedResponse = responseRepository.findById(savedResponse.getId()).orElse(null);
 
         assertNotNull(retrievedResponse);
-        assertEquals(updatedNotificationId, retrievedResponse.response().getNotificationId());
+        assertEquals(updatedNotificationId, retrievedResponse.getResponse().getNotificationId());
     }
 
     private SendEmailResponse createSampleEmailResponse(UUID templateId, UUID notificationId) {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationEmailResponseRepositoryTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.mongo.repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,6 +31,8 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
 
         assertNotNull(savedResponse);
         assertNotNull(savedResponse.getId());
+        assertNotNull(savedResponse.getCreatedAt());
+        assertNotNull(savedResponse.getUpdatedAt());
     }
 
     @Test
@@ -67,9 +68,9 @@ class NotificationEmailResponseRepositoryTest extends AbstractMongoDBTest {
         UUID updatedNotificationId = UUID.randomUUID();
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), createSampleEmailResponse(UUID.randomUUID(),initialNotificationId), "1"));
+                new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),initialNotificationId), "1"));
 
-        responseRepository.save(new NotificationEmailResponse(LocalDateTime.now(), LocalDateTime.now().plusHours(1), createSampleEmailResponse(UUID.randomUUID(),updatedNotificationId), savedResponse.getId()));
+        responseRepository.save(new NotificationEmailResponse(null, null, createSampleEmailResponse(UUID.randomUUID(),updatedNotificationId), savedResponse.getId()));
 
         NotificationEmailResponse retrievedResponse = responseRepository.findById(savedResponse.getId()).orElse(null);
 

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
@@ -29,6 +29,8 @@ class NotificationLetterRequestRepositoryTest extends AbstractMongoDBTest {
 
         assertNotNull(savedRequest);
         assertNotNull(savedRequest.getId());
+        assertNotNull(savedRequest.getCreatedAt());
+        assertNotNull(savedRequest.getUpdatedAt());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
@@ -25,29 +25,29 @@ class NotificationLetterRequestRepositoryTest extends AbstractMongoDBTest {
     @Test
     void When_NewRequestSaved_Expect_IdAssigned() {
         GovUkLetterDetailsRequest letterRequest = createSampleLetterRequest("123 Main St");
-        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, letterRequest));
+        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, null, letterRequest, null));
 
         assertNotNull(savedRequest);
-        assertNotNull(savedRequest.id());
+        assertNotNull(savedRequest.getId());
     }
 
     @Test
     void When_RequestSaved_Expect_DataCanBeRetrievedById() {
         GovUkLetterDetailsRequest letterRequest = createSampleLetterRequest("456 Oak Ave");
-        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, letterRequest));
+        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, null, letterRequest, null));
 
-        Optional<NotificationLetterRequest> retrievedRequest = requestRepository.findById(savedRequest.id());
+        Optional<NotificationLetterRequest> retrievedRequest = requestRepository.findById(savedRequest.getId());
 
         assertTrue(retrievedRequest.isPresent());
-        assertEquals(savedRequest.id(), retrievedRequest.get().id());
-        assertEquals("456 Oak Ave", retrievedRequest.get().request().getRecipientDetails().getPhysicalAddress().getAddressLine1());
+        assertEquals(savedRequest.getId(), retrievedRequest.get().getId());
+        assertEquals("456 Oak Ave", retrievedRequest.get().getRequest().getRecipientDetails().getPhysicalAddress().getAddressLine1());
     }
 
     @Test
     void When_MultipleRequestsSaved_Expect_AllCanBeRetrieved() {
-        requestRepository.save(new NotificationLetterRequest(null, createSampleLetterRequest("123 First St")));
-        requestRepository.save(new NotificationLetterRequest(null, createSampleLetterRequest("456 Second Ave")));
-        requestRepository.save(new NotificationLetterRequest(null, createSampleLetterRequest("789 Third Blvd")));
+        requestRepository.save(new NotificationLetterRequest(null, null, createSampleLetterRequest("123 First St"), null));
+        requestRepository.save(new NotificationLetterRequest(null, null, createSampleLetterRequest("456 Second Ave"), null));
+        requestRepository.save(new NotificationLetterRequest(null, null, createSampleLetterRequest("789 Third Blvd"), null));
 
         List<NotificationLetterRequest> allRequests = requestRepository.findAll();
 
@@ -56,26 +56,26 @@ class NotificationLetterRequestRepositoryTest extends AbstractMongoDBTest {
 
     @Test
     void When_RequestDeleted_Expect_RequestNotFoundById() {
-        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, createSampleLetterRequest("Test Address")));
+        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, null, createSampleLetterRequest("Test Address"), null));
 
-        requestRepository.deleteById(savedRequest.id());
+        requestRepository.deleteById(savedRequest.getId());
 
-        Optional<NotificationLetterRequest> deletedRequest = requestRepository.findById(savedRequest.id());
+        Optional<NotificationLetterRequest> deletedRequest = requestRepository.findById(savedRequest.getId());
         assertFalse(deletedRequest.isPresent());
     }
 
     @Test
     void When_RequestUpdated_Expect_ChangesReflectedInDatabase() {
         GovUkLetterDetailsRequest initialRequest = createSampleLetterRequest("Initial Address");
-        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, initialRequest));
+        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, null, initialRequest, null));
 
         GovUkLetterDetailsRequest updatedRequest = createSampleLetterRequest("Updated Address");
-        requestRepository.save(new NotificationLetterRequest(savedRequest.id(), updatedRequest));
+        requestRepository.save(new NotificationLetterRequest(null, null, updatedRequest, savedRequest.getId()));
 
-        NotificationLetterRequest retrievedRequest = requestRepository.findById(savedRequest.id()).orElse(null);
+        NotificationLetterRequest retrievedRequest = requestRepository.findById(savedRequest.getId()).orElse(null);
 
         assertNotNull(retrievedRequest);
-        assertEquals("Updated Address", retrievedRequest.request().getRecipientDetails().getPhysicalAddress().getAddressLine1());
+        assertEquals("Updated Address", retrievedRequest.getRequest().getRecipientDetails().getPhysicalAddress().getAddressLine1());
     }
     
 }

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterRequestRepositoryTest.java
@@ -25,9 +25,14 @@ class NotificationLetterRequestRepositoryTest extends AbstractMongoDBTest {
     @Test
     void When_NewRequestSaved_Expect_IdAssigned() {
         GovUkLetterDetailsRequest letterRequest = createSampleLetterRequest("123 Main St");
-        NotificationLetterRequest savedRequest = requestRepository.save(new NotificationLetterRequest(null, null, letterRequest, null));
+        NotificationLetterRequest notificationLetterRequest = new NotificationLetterRequest();
+        notificationLetterRequest.setRequest(letterRequest);
+        notificationLetterRequest.setId(null);
+        notificationLetterRequest.setCreatedAt(null);
+        notificationLetterRequest.setUpdatedAt(null);
+        NotificationLetterRequest savedRequest = requestRepository.save(notificationLetterRequest);
 
-        assertNotNull(savedRequest);
+        assertNotNull(savedRequest.toString());
         assertNotNull(savedRequest.getId());
         assertNotNull(savedRequest.getCreatedAt());
         assertNotNull(savedRequest.getUpdatedAt());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
@@ -30,6 +30,8 @@ class NotificationLetterResponseRepositoryTest extends AbstractMongoDBTest {
 
         assertNotNull(savedResponse);
         assertNotNull(savedResponse.getId());
+        assertNotNull(savedResponse.getCreatedAt());
+        assertNotNull(savedResponse.getUpdatedAt());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
@@ -26,9 +26,15 @@ class NotificationLetterResponseRepositoryTest extends AbstractMongoDBTest {
     void When_NewResponseSaved_Expect_IdAssigned() {
         LetterResponse letterResponse = createSampleLetterResponse(UUID.randomUUID());
 
-        NotificationLetterResponse savedResponse = responseRepository.save(new NotificationLetterResponse(null, null, letterResponse, null));
+        NotificationLetterResponse notificationLetterResponse = new NotificationLetterResponse();
+        notificationLetterResponse.setCreatedAt(null);
+        notificationLetterResponse.setUpdatedAt(null);
+        notificationLetterResponse.setResponse(letterResponse);
+        notificationLetterResponse.setId(null);
 
-        assertNotNull(savedResponse);
+        NotificationLetterResponse savedResponse = responseRepository.save(notificationLetterResponse);
+
+        assertNotNull(savedResponse.toString());
         assertNotNull(savedResponse.getId());
         assertNotNull(savedResponse.getCreatedAt());
         assertNotNull(savedResponse.getUpdatedAt());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationLetterResponseRepositoryTest.java
@@ -26,10 +26,10 @@ class NotificationLetterResponseRepositoryTest extends AbstractMongoDBTest {
     void When_NewResponseSaved_Expect_IdAssigned() {
         LetterResponse letterResponse = createSampleLetterResponse(UUID.randomUUID());
 
-        NotificationLetterResponse savedResponse = responseRepository.save(new NotificationLetterResponse(null, letterResponse));
+        NotificationLetterResponse savedResponse = responseRepository.save(new NotificationLetterResponse(null, null, letterResponse, null));
 
         assertNotNull(savedResponse);
-        assertNotNull(savedResponse.id());
+        assertNotNull(savedResponse.getId());
     }
 
     @Test
@@ -38,24 +38,24 @@ class NotificationLetterResponseRepositoryTest extends AbstractMongoDBTest {
         LetterResponse letterResponse = createSampleLetterResponse(notificationId);
 
         NotificationLetterResponse savedResponse = responseRepository.save(
-                new NotificationLetterResponse(null, letterResponse));
+                new NotificationLetterResponse(null, null, letterResponse, null));
 
-        Optional<NotificationLetterResponse> retrievedResponse = responseRepository.findById(savedResponse.id());
+        Optional<NotificationLetterResponse> retrievedResponse = responseRepository.findById(savedResponse.getId());
 
         assertTrue(retrievedResponse.isPresent());
-        assertEquals(savedResponse.id(), retrievedResponse.get().id());
-        assertEquals(notificationId, retrievedResponse.get().response().getNotificationId());
+        assertEquals(savedResponse.getId(), retrievedResponse.get().getId());
+        assertEquals(notificationId, retrievedResponse.get().getResponse().getNotificationId());
     }
 
 
     @Test
     void When_ResponseDeleted_Expect_ResponseNotFoundById() {
         NotificationLetterResponse savedResponse = responseRepository.save(
-                new NotificationLetterResponse(null, createSampleLetterResponse(UUID.randomUUID())));
+                new NotificationLetterResponse(null, null, createSampleLetterResponse(UUID.randomUUID()), null));
 
-        responseRepository.deleteById(savedResponse.id());
+        responseRepository.deleteById(savedResponse.getId());
 
-        Optional<NotificationLetterResponse> deletedResponse = responseRepository.findById(savedResponse.id());
+        Optional<NotificationLetterResponse> deletedResponse = responseRepository.findById(savedResponse.getId());
         assertFalse(deletedResponse.isPresent());
     }
 
@@ -65,15 +65,15 @@ class NotificationLetterResponseRepositoryTest extends AbstractMongoDBTest {
         UUID updatedNotificationId = UUID.randomUUID();
 
         NotificationLetterResponse savedResponse = responseRepository.save(
-                new NotificationLetterResponse(null, createSampleLetterResponse(initialNotificationId)));
+                new NotificationLetterResponse(null, null, createSampleLetterResponse(initialNotificationId), null));
 
-        responseRepository.save(new NotificationLetterResponse(savedResponse.id(),
-                createSampleLetterResponse(updatedNotificationId)));
+        responseRepository.save(new NotificationLetterResponse(null, null,
+                createSampleLetterResponse(updatedNotificationId), savedResponse.getId()));
 
-        NotificationLetterResponse retrievedResponse = responseRepository.findById(savedResponse.id()).orElse(null);
+        NotificationLetterResponse retrievedResponse = responseRepository.findById(savedResponse.getId()).orElse(null);
 
         assertNotNull(retrievedResponse);
-        assertEquals(updatedNotificationId, retrievedResponse.response().getNotificationId());
+        assertEquals(updatedNotificationId, retrievedResponse.getResponse().getNotificationId());
     }
 
     private LetterResponse createSampleLetterResponse(UUID notificationId) {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
@@ -35,20 +35,19 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
     void When_NewStatusSaved_Expect_IdAssigned() {
         TestData testData = setupTestDataWithRequestAndResponse();
 
-        NotificationStatus status = new NotificationStatus(
-                null,
-                null,
-                testData.requestId,
-                testData.responseId,
-                "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z"),
-                null
-        );
+        NotificationStatus notificationStatus = new NotificationStatus();
+        notificationStatus.setCreatedAt(null);
+        notificationStatus.setUpdatedAt(null);
+        notificationStatus.setRequestId(testData.requestId);
+        notificationStatus.setResponseId(testData.responseId);
+        notificationStatus.setStatus("SENT");
+        notificationStatus.setStatusDetails(Map.of("sentAt", "2023-03-15T14:30:00Z"));
+        notificationStatus.setId(null);
 
 
-        NotificationStatus savedStatus = statusRepository.save(status);
+        NotificationStatus savedStatus = statusRepository.save(notificationStatus);
 
-        assertNotNull(savedStatus);
+        assertNotNull(savedStatus.toString());
         assertNotNull(savedStatus.getId());
         assertNotNull(savedStatus.getCreatedAt());
         assertNotNull(savedStatus.getUpdatedAt());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
@@ -50,6 +50,8 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
 
         assertNotNull(savedStatus);
         assertNotNull(savedStatus.getId());
+        assertNotNull(savedStatus.getCreatedAt());
+        assertNotNull(savedStatus.getUpdatedAt());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/repository/NotificationStatusRepositoryTest.java
@@ -37,16 +37,19 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
 
         NotificationStatus status = new NotificationStatus(
                 null,
+                null,
                 testData.requestId,
                 testData.responseId,
                 "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")
+                Map.of("sentAt", "2023-03-15T14:30:00Z"),
+                null
         );
+
 
         NotificationStatus savedStatus = statusRepository.save(status);
 
         assertNotNull(savedStatus);
-        assertNotNull(savedStatus.id());
+        assertNotNull(savedStatus.getId());
     }
 
     @Test
@@ -55,19 +58,21 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
 
         NotificationStatus status = new NotificationStatus(
                 null,
+                null,
                 testData.requestId,
                 testData.responseId,
                 "DELIVERED",
-                Map.of("deliveredAt", "2023-03-15T14:32:00Z")
+                Map.of("deliveredAt", "2023-03-15T14:32:00Z"),
+                null
         );
 
         NotificationStatus savedStatus = statusRepository.save(status);
 
-        Optional<NotificationStatus> retrievedStatus = statusRepository.findById(savedStatus.id());
+        Optional<NotificationStatus> retrievedStatus = statusRepository.findById(savedStatus.getId());
 
         assertTrue(retrievedStatus.isPresent());
-        assertEquals(savedStatus.id(), retrievedStatus.get().id());
-        assertEquals("DELIVERED", retrievedStatus.get().status());
+        assertEquals(savedStatus.getId(), retrievedStatus.get().getId());
+        assertEquals("DELIVERED", retrievedStatus.get().getStatus());
     }
 
     @Test
@@ -76,10 +81,12 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
 
         NotificationStatus status = new NotificationStatus(
                 null,
+                null,
                 testData.requestId,
                 testData.responseId,
                 "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")
+                Map.of("sentAt", "2023-03-15T14:30:00Z"),
+                null
         );
 
         statusRepository.save(status);
@@ -87,7 +94,7 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
         List<NotificationStatus> statuses = statusRepository.findByRequestId(testData.requestId);
 
         assertEquals(1, statuses.size());
-        assertEquals("SENT", statuses.getFirst().status());
+        assertEquals("SENT", statuses.getFirst().getStatus());
     }
 
     @Test
@@ -96,10 +103,12 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
 
         NotificationStatus status = new NotificationStatus(
                 null,
+                null,
                 testData.requestId,
                 testData.responseId,
                 "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")
+                Map.of("sentAt", "2023-03-15T14:30:00Z"),
+                null
         );
 
         statusRepository.save(status);
@@ -107,7 +116,7 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
         List<NotificationStatus> statuses = statusRepository.findByResponseId(testData.responseId);
 
         assertEquals(1, statuses.size());
-        assertEquals("SENT", statuses.getFirst().status());
+        assertEquals("SENT", statuses.getFirst().getStatus());
     }
 
     @Test
@@ -115,11 +124,11 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
         TestData testData = setupTestDataWithRequestAndResponse();
 
         statusRepository.save(new NotificationStatus(
-                null, testData.requestId, testData.responseId, "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")));
+                null, null, testData.requestId, testData.responseId, "SENT",
+                Map.of("sentAt", "2023-03-15T14:30:00Z"), null));
         statusRepository.save(new NotificationStatus(
-                null, testData.requestId, testData.responseId, "DELIVERED",
-                Map.of("deliveredAt", "2023-03-15T14:32:00Z")));
+                null, null, testData.requestId, testData.responseId, "DELIVERED",
+                Map.of("deliveredAt", "2023-03-15T14:32:00Z"), null));
 
         List<NotificationStatus> statuses = statusRepository.findByResponseId(testData.responseId);
 
@@ -131,12 +140,12 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
         TestData testData = setupTestDataWithRequestAndResponse();
 
         NotificationStatus savedStatus = statusRepository.save(new NotificationStatus(
-                null, testData.requestId, testData.responseId, "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")));
+                null, null, testData.requestId, testData.responseId, "SENT",
+                Map.of("sentAt", "2023-03-15T14:30:00Z"), null));
 
-        statusRepository.deleteById(savedStatus.id());
+        statusRepository.deleteById(savedStatus.getId());
 
-        Optional<NotificationStatus> deletedStatus = statusRepository.findById(savedStatus.id());
+        Optional<NotificationStatus> deletedStatus = statusRepository.findById(savedStatus.getId());
         assertFalse(deletedStatus.isPresent());
     }
 
@@ -145,28 +154,28 @@ class NotificationStatusRepositoryTest extends AbstractMongoDBTest {
         TestData testData = setupTestDataWithRequestAndResponse();
 
         NotificationStatus savedStatus = statusRepository.save(new NotificationStatus(
-                null, testData.requestId, testData.responseId, "SENT",
-                Map.of("sentAt", "2023-03-15T14:30:00Z")));
+                null, null, testData.requestId, testData.responseId, "SENT",
+                Map.of("sentAt", "2023-03-15T14:30:00Z"), null));
 
         statusRepository.save(new NotificationStatus(
-                savedStatus.id(), testData.requestId, testData.responseId, "FAILED",
-                Map.of("failedAt", "2023-03-15T14:35:00Z", "reason", "Invalid email")));
+                null, null, testData.requestId, testData.responseId, "FAILED",
+                Map.of("failedAt", "2023-03-15T14:35:00Z", "reason", "Invalid email"), savedStatus.getId()));
 
-        NotificationStatus retrievedStatus = statusRepository.findById(savedStatus.id()).orElse(null);
+        NotificationStatus retrievedStatus = statusRepository.findById(savedStatus.getId()).orElse(null);
 
         assertNotNull(retrievedStatus);
-        assertEquals("FAILED", retrievedStatus.status());
-        assertEquals("Invalid email", retrievedStatus.statusDetails().get("reason"));
+        assertEquals("FAILED", retrievedStatus.getStatus());
+        assertEquals("Invalid email", retrievedStatus.getStatusDetails().get("reason"));
     }
 
     private TestData setupTestDataWithRequestAndResponse() {
         NotificationEmailRequest savedRequest = requestRepository.save(createSampleNotificationRequest());
 
         NotificationEmailResponse savedResponse = responseRepository.save(
-                new NotificationEmailResponse(null, createSampleEmailResponse())
+                new NotificationEmailResponse(null, null, createSampleEmailResponse(), null)
         );
 
-        return new TestData(savedRequest.id(), savedResponse.id());
+        return new TestData(savedRequest.getId(), savedResponse.getId());
     }
 
     private static class TestData {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseServiceTest.java
@@ -22,12 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleEmailRequest;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleEmailRequestWithReference;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleEmailResponse;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleLetterRequest;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleLetterRequestWithReference;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.createSampleLetterResponse;
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.TestUtils.*;
 
 @SpringBootTest
 class NotificationDatabaseServiceTest extends AbstractMongoDBTest {

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/mongo/service/NotificationDatabaseServiceTest.java
@@ -41,20 +41,20 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
         NotificationEmailRequest savedRequest = notificationDatabaseService.storeEmail(emailRequest);
 
         assertNotNull(savedRequest);
-        assertNotNull(savedRequest.id());
+        assertNotNull(savedRequest.getId());
     }
 
     @Test
     void When_GetEmail_ThenEmailRetrieved() {
         GovUkEmailDetailsRequest emailRequest = createSampleEmailRequest("jane.smith@example.com");
         NotificationEmailRequest savedRequest = notificationDatabaseService.storeEmail(emailRequest);
-        String id = savedRequest.id();
+        String id = savedRequest.getId();
 
         Optional<NotificationEmailRequest> retrievedRequest = notificationDatabaseService.getEmail(id);
 
         assertTrue(retrievedRequest.isPresent());
-        assertEquals(id, retrievedRequest.get().id());
-        assertEquals("jane.smith@example.com", retrievedRequest.get().request().getRecipientDetails().getEmailAddress());
+        assertEquals(id, retrievedRequest.get().getId());
+        assertEquals("jane.smith@example.com", retrievedRequest.get().getRequest().getRecipientDetails().getEmailAddress());
     }
 
     @Test
@@ -81,20 +81,20 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
         NotificationLetterRequest savedRequest = notificationDatabaseService.storeLetter(letterRequest);
 
         assertNotNull(savedRequest);
-        assertNotNull(savedRequest.id());
+        assertNotNull(savedRequest.getId());
     }
 
     @Test
     void When_GetLetter_ThenLetterRetrieved() {
         GovUkLetterDetailsRequest letterRequest = createSampleLetterRequest("456 High Street");
         NotificationLetterRequest savedRequest = notificationDatabaseService.storeLetter(letterRequest);
-        String id = savedRequest.id();
+        String id = savedRequest.getId();
 
         Optional<NotificationLetterRequest> retrievedRequest = notificationDatabaseService.getLetter(id);
 
         assertTrue(retrievedRequest.isPresent());
-        assertEquals(id, retrievedRequest.get().id());
-        assertEquals("456 High Street", retrievedRequest.get().request().getRecipientDetails().getPhysicalAddress().getAddressLine1());
+        assertEquals(id, retrievedRequest.get().getId());
+        assertEquals("456 High Street", retrievedRequest.get().getRequest().getRecipientDetails().getPhysicalAddress().getAddressLine1());
     }
 
     @Test
@@ -127,21 +127,23 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
 
         NotificationStatus status = new NotificationStatus(
                 null,
+                null,
                 requestId,
                 responseId,
                 "SENT",
-                statusDetails
+                statusDetails,
+                null
         );
 
         NotificationStatus savedStatus = notificationDatabaseService.updateStatus(status);
 
         assertNotNull(savedStatus);
-        assertNotNull(savedStatus.id());
-        assertEquals(requestId, savedStatus.requestId());
-        assertEquals(responseId, savedStatus.responseId());
-        assertEquals("SENT", savedStatus.status());
-        assertNotNull(savedStatus.statusDetails());
-        assertEquals("Email sent successfully", savedStatus.statusDetails().get("message"));
+        assertNotNull(savedStatus.getId());
+        assertEquals(requestId, savedStatus.getRequestId());
+        assertEquals(responseId, savedStatus.getResponseId());
+        assertEquals("SENT", savedStatus.getStatus());
+        assertNotNull(savedStatus.getStatusDetails());
+        assertEquals("Email sent successfully", savedStatus.getStatusDetails().get("message"));
     }
 
     @Test
@@ -154,7 +156,7 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
 
         assertNotNull(retrievedEmails);
         assertFalse(retrievedEmails.isEmpty());
-        assertEquals(reference, retrievedEmails.get(0).request().getSenderDetails().getReference());
+        assertEquals(reference, retrievedEmails.get(0).getRequest().getSenderDetails().getReference());
     }
 
     @Test
@@ -175,7 +177,7 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
 
         assertNotNull(retrievedLetters);
         assertFalse(retrievedLetters.isEmpty());
-        assertEquals(reference, retrievedLetters.get(0).request().getSenderDetails().getReference());
+        assertEquals(reference, retrievedLetters.get(0).getRequest().getSenderDetails().getReference());
     }
 
     @Test
@@ -213,8 +215,8 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
 
         assertNotNull(retrievedEmails);
         assertEquals(2, retrievedEmails.size());
-        assertEquals(reference, retrievedEmails.get(0).request().getSenderDetails().getReference());
-        assertEquals(reference, retrievedEmails.get(1).request().getSenderDetails().getReference());
+        assertEquals(reference, retrievedEmails.get(0).getRequest().getSenderDetails().getReference());
+        assertEquals(reference, retrievedEmails.get(1).getRequest().getSenderDetails().getReference());
     }
 
     @Test
@@ -230,7 +232,7 @@ class NotificationDatabaseServiceTest extends AbstractMongoDBTest {
 
         assertNotNull(retrievedLetters);
         assertEquals(2, retrievedLetters.size());
-        assertEquals(reference, retrievedLetters.get(0).request().getSenderDetails().getReference());
-        assertEquals(reference, retrievedLetters.get(1).request().getSenderDetails().getReference());
+        assertEquals(reference, retrievedLetters.get(0).getRequest().getSenderDetails().getReference());
+        assertEquals(reference, retrievedLetters.get(1).getRequest().getSenderDetails().getReference());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/ReaderRestApiIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/ReaderRestApiIntegrationTest.java
@@ -100,7 +100,7 @@ class ReaderRestApiIntegrationTest extends AbstractMongoDBTest {
     void When_RequestingEmailById_Expect_SuccessfulResponseWithMatchingEmail() throws Exception {
         GovUkEmailDetailsRequest emailRequest = TestUtils.createSampleEmailRequest(TEST_EMAIL);
         NotificationEmailRequest savedEmail = notificationDatabaseService.storeEmail(emailRequest);
-        String emailId = savedEmail.id();
+        String emailId = savedEmail.getId();
 
         MvcResult result = mockMvc.perform(get("/gov-uk-notify-integration/email/" + emailId)
                         .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiIntegrationTest.java
@@ -334,7 +334,7 @@ class SenderRestApiIntegrationTest extends AbstractMongoDBTest {
                 resourceToString("/fixtures/send-letter-request.json", UTF_8),
                 GovUkLetterDetailsRequest.class);
         assertThat(notificationDatabaseService.findAllLetters().isEmpty(), is(false));
-        var storedRequest = notificationDatabaseService.findAllLetters().getFirst().request();
+        var storedRequest = notificationDatabaseService.findAllLetters().getFirst().getRequest();
         assertThat(storedRequest, is(sentRequest));
     }
 
@@ -344,7 +344,7 @@ class SenderRestApiIntegrationTest extends AbstractMongoDBTest {
 
     private void verifyLetterResponseStoredCorrectly(LetterResponse receivedResponse) {
         assertThat(notificationLetterResponseRepository.findAll().isEmpty(), is(false));
-        var storedResponse = notificationLetterResponseRepository.findAll().getFirst().response();
+        var storedResponse = notificationLetterResponseRepository.findAll().getFirst().getResponse();
         // Unfortunately SendLetter does not implement equals() and hashCode().
         assertThat(storedResponse.toString(), is(receivedResponse.toString()));
     }
@@ -362,13 +362,13 @@ class SenderRestApiIntegrationTest extends AbstractMongoDBTest {
         var storedResponse = notificationLetterResponseRepository.findAll().getFirst();
 
         // Ensure the stored response contains information about the error encountered.
-        assertThat(storedResponse.id(), is(notNullValue()));
-        assertThat(storedResponse.response(), is(notNullValue()));
-        assertThat(storedResponse.response().getNotificationId(), is(NIL_UUID));
-        assertThat(storedResponse.response().getReference().isPresent(), is(true));
-        assertThat(storedResponse.response().getReference().get(), is("send-letter-request"));
-        assertThat(storedResponse.response().getData(), is(notNullValue()));
-        var data = storedResponse.response().getData();
+        assertThat(storedResponse.getId(), is(notNullValue()));
+        assertThat(storedResponse.getResponse(), is(notNullValue()));
+        assertThat(storedResponse.getResponse().getNotificationId(), is(NIL_UUID));
+        assertThat(storedResponse.getResponse().getReference().isPresent(), is(true));
+        assertThat(storedResponse.getResponse().getReference().get(), is("send-letter-request"));
+        assertThat(storedResponse.getResponse().getData(), is(notNullValue()));
+        var data = storedResponse.getResponse().getData();
         assertThat(data.get("data"), is(notNullValue()));
         var map = ((JSONObject) data.get("data")).get("map");
         assertThat(map, is(notNullValue()));


### PR DESCRIPTION
DEEP-321 - Add creation and modification timestamps to Notify Integration API MongoDB documents

__Add MongoDB auditing fields and convert the immutable record classes to standard classes in the to enable proper document modification tracking.__

* [x] All document classes are converted from records to standard classes with proper getters/setters
* [x] All document classes include @Field("created_at") @CreatedDate private LocalDateTime createdAt field
* [x] All document classes include @Field("updated_at") @LastModifiedDate private LocalDateTime updatedAt field
* [x] Integration tests verify timestamp fields are automatically populated on save/update operations
* [x] No regression in existing functionality

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__