### PR TITLE
Add GOV.UK Notify mock implementation for non-production environments

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/config/ApplicationConfig.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.config;
 
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.ChsGovUkNotifyIntegrationService.APPLICATION_NAMESPACE;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.service.notify.NotificationClient;
+
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.ChsGovUkNotifyIntegrationService.APPLICATION_NAMESPACE;
 
 @Configuration
 public class ApplicationConfig {
@@ -27,13 +28,14 @@ public class ApplicationConfig {
 
     /**
      * Creates NotificationClient that provides communication with
-     * the Gov Notify service.
+     * the Gov Notify service. Only used in production environments
+     * or when the mock is not active in other environments.
      *
      * @return the notification client
      */
     @Bean
+    @Profile("!local & !dev & !test")
     public NotificationClient getNotificationClient() {
         return new NotificationClient(apiKey);
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApi.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApi.java
@@ -1,14 +1,15 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.restapi;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -75,6 +76,7 @@ public class SenderRestApi implements NotifyIntegrationSenderControllerInterface
         var emailResp = govUkNotifyService.sendEmail(
                 govUkEmailDetailsRequest.getRecipientDetails().getEmailAddress(),
                 govUkEmailDetailsRequest.getEmailDetails().getTemplateId(),
+                govUkEmailDetailsRequest.getSenderDetails().getReference(),
                 personalisationDetails
         );
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/service/GovUkNotifyService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/service/GovUkNotifyService.java
@@ -1,16 +1,15 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.service;
 
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.ChsGovUkNotifyIntegrationService.APPLICATION_NAMESPACE;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -18,6 +17,8 @@ import uk.gov.service.notify.LetterResponse;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
+
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.ChsGovUkNotifyIntegrationService.APPLICATION_NAMESPACE;
 
 
 @Service
@@ -42,8 +43,8 @@ public class GovUkNotifyService {
     public EmailResp sendEmail(
             @NotBlank @Email String recipient,
             @NotBlank String templateId,
+            @NotBlank String reference,
             Map<String, ?> personalisation) {
-        String reference = recipient + "-" + System.currentTimeMillis();
         try {
             SendEmailResponse response = client.sendEmail(templateId, recipient, personalisation, reference);
             return new EmailResp(response != null && response.getNotificationId() != null, response);

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/MockNotificationClient.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/MockNotificationClient.java
@@ -1,0 +1,260 @@
+package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.test;
+
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.service.notify.LetterResponse;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.SendEmailResponse;
+
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.ChsGovUkNotifyIntegrationService.APPLICATION_NAMESPACE;
+
+@Component
+@Primary
+@Profile({"local", "dev", "test"}) // Only active in non-production environments
+public class MockNotificationClient extends NotificationClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
+
+    public static final String MOCK_REFERENCE_PREFIX = "use-mock-notify";
+
+    private static final String RATE_LIMIT_EXCEEDED = "Rate limit exceeded";
+    private static final String SIMULATED_SERVER_ERROR = "Simulated server error";
+    private static final String DEFAULT_KEY = "default";
+
+    private final Map<String, List<Long>> minuteRequests = new ConcurrentHashMap<>();
+    private final Map<String, AtomicInteger> dailyRateLimits = new ConcurrentHashMap<>();
+    private LocalDate lastDayReset = LocalDate.now();
+    private Supplier<Double> randomSupplier = Math::random;
+
+    @Value("${notify.mock.minute-limit:3000}")
+    private int minuteLimit;
+
+    @Value("${notify.mock.daily-limit:250000}")
+    private int dailyLimit;
+
+    @Value("${notify.mock.simulate-failures:false}")
+    private boolean simulateFailures;
+
+    @Value("${notify.mock.failure-rate:0.1}")
+    private double failureRate;
+
+    private Supplier<Long> currentTimeSupplier = System::currentTimeMillis;
+    private Supplier<LocalDate> currentDateSupplier = LocalDate::now;
+
+    private static class NotificationClientExceptionMock extends NotificationClientException {
+        private final int httpResult;
+
+        public NotificationClientExceptionMock(String message, int httpResult) {
+            super(message);
+            this.httpResult = httpResult;
+        }
+
+        @Override
+        public int getHttpResult() {
+            return this.httpResult;
+        }
+    }
+
+    public MockNotificationClient(@Value("${gov.uk.notify.api.key}") String apiKey) {
+        super(apiKey);
+        LOGGER.info("Using mock notification client, must be test environment.");
+    }
+
+    private boolean useRealGovNotify(String reference) {
+        return reference != null && !reference.startsWith(MOCK_REFERENCE_PREFIX);
+    }
+
+    @Override
+    public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, ?> personalisation,
+                                       String reference) throws NotificationClientException {
+        if (useRealGovNotify(reference)) {
+            return super.sendEmail(templateId, emailAddress, personalisation, reference);
+        }
+
+        if (isRateLimitExceeded()) {
+            throw new NotificationClientExceptionMock(RATE_LIMIT_EXCEEDED, 429);
+        }
+
+        if (shouldEmulateChanceFailure()) {
+            throw new NotificationClientExceptionMock(SIMULATED_SERVER_ERROR, 500);
+        }
+
+        String jsonResponse = createMockEmailResponse(templateId, reference);
+        return new SendEmailResponse(jsonResponse);
+    }
+
+    private boolean shouldEmulateChanceFailure() {
+        return simulateFailures && randomSupplier.get() < failureRate;
+    }
+
+    @Override
+    public LetterResponse sendPrecompiledLetterWithInputStream(String reference, InputStream precompiledPdf)
+            throws NotificationClientException {
+        if (useRealGovNotify(reference)) {
+            return super.sendPrecompiledLetterWithInputStream(reference, precompiledPdf);
+        }
+
+        if (isRateLimitExceeded()) {
+            throw new NotificationClientExceptionMock(RATE_LIMIT_EXCEEDED, 429);
+        }
+
+        if (shouldEmulateChanceFailure()) {
+            throw new NotificationClientExceptionMock(SIMULATED_SERVER_ERROR, 500);
+        }
+
+        String jsonResponse = createMockLetterResponse(reference);
+        return new LetterResponse(jsonResponse);
+    }
+
+    public boolean isRateLimitExceeded() {
+        long currentTime = getCurrentTimeMillis();
+
+        long cutoffTime = currentTime - 60000;
+        minuteRequests.computeIfPresent(DEFAULT_KEY, (k, timestamps) -> {
+            timestamps.removeIf(timestamp -> timestamp < cutoffTime);
+            return timestamps;
+        });
+
+        minuteRequests.putIfAbsent(DEFAULT_KEY, new CopyOnWriteArrayList<>());
+        List<Long> timestamps = minuteRequests.get(DEFAULT_KEY);
+        timestamps.add(currentTime);
+
+        if (timestamps.size() > minuteLimit) {
+            return true;
+        }
+
+        LocalDate today = getCurrentDate();
+        if (!today.equals(lastDayReset)) {
+            dailyRateLimits.clear();
+            lastDayReset = today;
+        }
+
+        dailyRateLimits.putIfAbsent(DEFAULT_KEY, new AtomicInteger(0));
+        int dailyCount = dailyRateLimits.get(DEFAULT_KEY).incrementAndGet();
+        return dailyCount > dailyLimit;
+    }
+
+    public String createMockEmailResponse(String templateId, String reference) {
+        var notificationId = UUID.randomUUID().toString();
+
+        JSONObject content = new JSONObject()
+                .put("subject", "Mock Subject")
+                .put("body", "This is a mocked email response")
+                .put("from_email", "mock.sender@notifications.service.gov.uk");
+
+        JSONObject template = new JSONObject()
+                .put("id", templateId)
+                .put("version", 1)
+                .put("uri", "https://api.notifications.service.gov.uk/v2/template/" + templateId);
+
+        JSONObject response = new JSONObject()
+                .put("id", notificationId)
+                .put("reference", reference != null ? reference : "")
+                .put("content", content)
+                .put("template", template);
+
+        return response.toString();
+    }
+
+    public String createMockLetterResponse(String reference) {
+        var notificationId = UUID.randomUUID().toString();
+        var templateId = UUID.randomUUID().toString();
+
+        JSONObject content = new JSONObject()
+                .put("subject", "Mock Letter")
+                .put("body", "This is a mocked letter response");
+
+        JSONObject template = new JSONObject()
+                .put("id", templateId)
+                .put("version", 1)
+                .put("uri", "https://api.notifications.service.gov.uk/v2/template/" + templateId);
+
+        JSONObject response = new JSONObject()
+                .put("id", notificationId)
+                .put("reference", reference != null ? reference : "")
+                .put("content", content)
+                .put("scheduled_for", JSONObject.NULL)
+                .put("template", template);
+
+        return response.toString();
+    }
+
+    public void resetRateLimits() {
+        minuteRequests.clear();
+        dailyRateLimits.clear();
+    }
+
+    public int getMinuteLimit() {
+        return minuteLimit;
+    }
+
+    public void setMinuteLimit(int minuteLimit) {
+        this.minuteLimit = minuteLimit;
+    }
+
+    public int getDailyLimit() {
+        return dailyLimit;
+    }
+
+    public void setDailyLimit(int dailyLimit) {
+        this.dailyLimit = dailyLimit;
+    }
+
+    public void setSimulateFailures(boolean simulateFailures) {
+        this.simulateFailures = simulateFailures;
+    }
+
+    public void setFailureRate(double failureRate) {
+        this.failureRate = failureRate;
+    }
+
+    protected long getCurrentTimeMillis() {
+        return currentTimeSupplier.get();
+    }
+
+    protected LocalDate getCurrentDate() {
+        return currentDateSupplier.get();
+    }
+
+    public void setCurrentTimeSupplier(Supplier<Long> currentTimeSupplier) {
+        this.currentTimeSupplier = currentTimeSupplier;
+    }
+
+    public void setCurrentDateSupplier(Supplier<LocalDate> currentDateSupplier) {
+        this.currentDateSupplier = currentDateSupplier;
+    }
+
+    public int getCurrentMinuteRequestCount() {
+        if (!minuteRequests.containsKey(DEFAULT_KEY)) {
+            return 0;
+        }
+        return minuteRequests.get(DEFAULT_KEY).size();
+    }
+
+    public int getCurrentDailyRequestCount() {
+        if (!dailyRateLimits.containsKey(DEFAULT_KEY)) {
+            return 0;
+        }
+        return dailyRateLimits.get(DEFAULT_KEY).get();
+    }
+
+    public void setRandomSupplier(Supplier<Double> randomSupplier) {
+        this.randomSupplier = randomSupplier;
+    }
+} 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/README.md
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/README.md
@@ -1,0 +1,63 @@
+# GOV.UK Notify Mock Implementation
+
+This package provides a transparent mock implementation of the GOV.UK Notify service that can be used for development
+and testing purposes.
+
+## Features
+
+- Automatically activates only in non-production environments (`local`, `dev`, `test` profiles)
+- Can be toggled on/off via reference prefixes without changing any application code
+- Seamlessly falls back to the real implementation when references don't match the pattern
+- Simulates rate limiting with configurable limits
+- Provides realistic mock responses for emails and letters
+- Can simulate random failures at configurable rates
+
+## How It Works
+
+The mock implementation uses Spring's profile-based autowiring to automatically substitute the real NotificationClient
+with a mock version in non-production environments. The mock version checks each reference to determine whether to use
+mock behavior:
+
+- When a reference starts with `use-mock-notify`, mock behaviors are used
+- When a reference doesn't match the pattern, calls are delegated to the real NotificationClient
+
+## Configuration
+
+The mock is configured through application properties:
+
+```properties
+# Mock configuration for non-production environments
+# These will only be used when active profile is local, dev, or test
+# and when the reference starts with "use-mock-notify"
+notify.mock.minute-limit=3000
+notify.mock.daily-limit=250000
+notify.mock.simulate-failures=false
+notify.mock.failure-rate=0.1
+```
+
+## Rate Limiting and Failure Simulation
+
+The mock provides realistic rate limiting simulation with both per-minute and daily limits:
+
+Based on the limits defined here: https://docs.notifications.service.gov.uk/java.html#limits
+
+1. **Per-minute rate limiting**:
+    - Default: 3000 requests/minute
+    - When exceeded: Returns HTTP 429 error
+    - Automatically resets after one minute has passed
+
+2. **Daily rate limiting**:
+    - Default: 250,000 requests/day
+    - When exceeded: Returns HTTP 429 error
+    - Resets at the start of a new day
+
+3. **Failure simulation**:
+    - Can be configured to randomly fail requests
+    - Configurable failure rate (0.0 to 1.0)
+    - Returns HTTP 500 errors when triggered
+
+## Safety Features
+
+- Mock is only activated in non-production environments through Spring profiles
+- Production environments always use the real implementation regardless of reference patterns
+- The mock client proxies to the real implementation when references don't match the pattern

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 spring.data.mongodb.uri=${MONGODB_URL:mongodb://localhost:27017}
 spring.data.mongodb.database=${MONGODB_DATABASE:notification}
 spring.data.mongodb.auto-index-creation=true
+spring.profiles.active=${PROFILE:default}
 
 # Actuator health check config
 management.endpoint.health.show-details=always
@@ -35,4 +36,10 @@ signin.url=${CHS_URL}/signin
 
 email.producer.appId=chs-gov-uk-notify-integration-api
 gov.uk.notify.api.key=${CHS_GOV_UK_NOTIFY_INTEGRATION_API_KEY}
-
+# Mock configuration for non-production environments
+# These will only be used when active profile is local, dev, or test
+# and when the reference starts with "use-mock-notify"
+notify.mock.minute-limit=3000
+notify.mock.daily-limit=250000
+notify.mock.simulate-failures=false
+notify.mock.failure-rate=0.1

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiTests.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/SenderRestApiTests.java
@@ -51,6 +51,7 @@ class SenderRestApiTests {
 
     private static final String VALID_EMAIL = "test@example.com";
     private static final String VALID_TEMPLATE_ID = "valid-template-id";
+    private static final String VALID_REFERENCE = "valid-reference";
     private static final Map<String, String> VALID_PERSONALISATION = Map.of("name", "Test User");
     private static final String XHEADER = "1";
 
@@ -64,7 +65,7 @@ class SenderRestApiTests {
                 .emailAddress("john.doe@example.com")
                 .userId("9876543")
                 .name("John Doe")
-                .reference("ref")
+                .reference(VALID_REFERENCE)
                 .appId("chips.send_email"));
         govUkEmailDetailsRequest.setEmailDetails(emailDetails
                 .templateId(VALID_TEMPLATE_ID)
@@ -74,7 +75,7 @@ class SenderRestApiTests {
                 .emailAddress(VALID_EMAIL)
                 .name("john doe"));
 
-        when(govUKNotifyEmailFacade.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION)).thenReturn(new GovUkNotifyService.EmailResp(true, null));
+        when(govUKNotifyEmailFacade.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION)).thenReturn(new GovUkNotifyService.EmailResp(true, null));
 
         ResponseEntity<Void> response = notifyIntegrationSenderController.sendEmail(govUkEmailDetailsRequest, XHEADER);
 
@@ -92,7 +93,7 @@ class SenderRestApiTests {
                 .emailAddress("john.doe@example.com")
                 .userId("9876543")
                 .name("John Doe")
-                .reference("ref")
+                .reference(VALID_REFERENCE)
                 .appId("chips.send_email"));
         govUkEmailDetailsRequest.setEmailDetails(emailDetails
                 .templateId(VALID_TEMPLATE_ID)
@@ -102,7 +103,7 @@ class SenderRestApiTests {
                 .emailAddress(VALID_EMAIL)
                 .name("john doe"));
 
-        when(govUKNotifyEmailFacade.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION)).thenReturn(new GovUkNotifyService.EmailResp(false, null));
+        when(govUKNotifyEmailFacade.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION)).thenReturn(new GovUkNotifyService.EmailResp(false, null));
 
         ResponseEntity<Void> response = notifyIntegrationSenderController.sendEmail(govUkEmailDetailsRequest, XHEADER);
 

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/service/GovUKNotifyServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/service/GovUKNotifyServiceTest.java
@@ -70,6 +70,7 @@ public class GovUKNotifyServiceTest {
 
     private static final String VALID_EMAIL = "test@example.com";
     private static final String VALID_TEMPLATE_ID = "valid-template-id";
+    private static final String VALID_REFERENCE = "valid-reference";
     private static final String VALID_RECIPIENT = "Test Recipient";
     private static final Map<String, String> VALID_PERSONALISATION = Map.of("name", "Test User");
 
@@ -94,7 +95,7 @@ public class GovUKNotifyServiceTest {
             when(mockEmailResponse.getNotificationId()).thenReturn(mockUuid);
             when(mockClient.sendEmail(anyString(), anyString(), anyMap(), anyString())).thenReturn(mockEmailResponse);
 
-            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION);
+            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION);
 
             assertTrue(result.success());
             assertEquals(mockEmailResponse, result.response());
@@ -106,7 +107,7 @@ public class GovUKNotifyServiceTest {
         void When_ClientReturnsNullResponse_Expect_SendEmailReturnsFalse() throws NotificationClientException {
             when(mockClient.sendEmail(anyString(), anyString(), anyMap(), anyString())).thenReturn(null);
 
-            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION);
+            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION);
 
             assertFalse(result.success());
             assertNull(result.response());
@@ -118,7 +119,7 @@ public class GovUKNotifyServiceTest {
             when(mockEmailResponse.getNotificationId()).thenReturn(null);
             when(mockClient.sendEmail(anyString(), anyString(), anyMap(), anyString())).thenReturn(mockEmailResponse);
 
-            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION);
+            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION);
 
             assertFalse(result.success());
             assertEquals(mockEmailResponse, result.response());
@@ -130,7 +131,7 @@ public class GovUKNotifyServiceTest {
             when(mockClient.sendEmail(anyString(), anyString(), anyMap(), anyString()))
                     .thenThrow(new NotificationClientException("Test exception"));
 
-            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_PERSONALISATION);
+            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION);
 
             assertFalse(result.success());
             assertNull(result.response());
@@ -143,7 +144,7 @@ public class GovUKNotifyServiceTest {
             when(mockEmailResponse.getNotificationId()).thenReturn(mockUuid);
             when(mockClient.sendEmail(anyString(), anyString(), isNull(), anyString())).thenReturn(mockEmailResponse);
 
-            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, null);
+            GovUkNotifyService.EmailResp result = govUkNotifyService.sendEmail(VALID_EMAIL, VALID_TEMPLATE_ID, VALID_REFERENCE, null);
 
             assertTrue(result.success());
             assertEquals(mockEmailResponse, result.response());
@@ -236,7 +237,7 @@ public class GovUKNotifyServiceTest {
         @ValueSource(strings = {"invalid-email", "missing-at.com", "@missinguser.com"})
         void When_EmailInvalidEmailProvided_Expect_ConstraintViolationException(String invalidEmail) {
             assertThrows(ConstraintViolationException.class, () ->
-                    govUkNotifyService.sendEmail(invalidEmail, VALID_TEMPLATE_ID, VALID_PERSONALISATION)
+                    govUkNotifyService.sendEmail(invalidEmail, VALID_TEMPLATE_ID, VALID_REFERENCE, VALID_PERSONALISATION)
             );
         }
 
@@ -245,7 +246,7 @@ public class GovUKNotifyServiceTest {
         @NullAndEmptySource
         void When_EmailInvalidTemplateIdProvided_Expect_ConstraintViolationException(String invalidTemplateId) {
             assertThrows(ConstraintViolationException.class, () ->
-                    govUkNotifyService.sendEmail(VALID_EMAIL, invalidTemplateId, VALID_PERSONALISATION)
+                    govUkNotifyService.sendEmail(VALID_EMAIL, invalidTemplateId, VALID_REFERENCE, VALID_PERSONALISATION)
             );
         }
 
@@ -255,7 +256,7 @@ public class GovUKNotifyServiceTest {
         void When_EmailMultipleInvalidInputsProvided_Expect_ConstraintViolationException(
                 String email, String templateId, String testDescription) {
             assertThrows(ConstraintViolationException.class, () ->
-                    govUkNotifyService.sendEmail(email, templateId, VALID_PERSONALISATION)
+                    govUkNotifyService.sendEmail(email, templateId, VALID_REFERENCE, VALID_PERSONALISATION)
             );
         }
 

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/MockNotificationClientRateLimitTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/test/MockNotificationClientRateLimitTest.java
@@ -1,0 +1,424 @@
+package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.service.notify.LetterResponse;
+import uk.gov.service.notify.NotificationClientException;
+import uk.gov.service.notify.SendEmailResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MockNotificationClientRateLimitTest {
+
+    @Autowired
+    private MockNotificationClient mockClient;
+
+    private static final String MOCK_REFERENCE = MockNotificationClient.MOCK_REFERENCE_PREFIX + "-test";
+    private static final String TEST_TEMPLATE_ID = UUID.randomUUID().toString();
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final InputStream TEST_PDF = new ByteArrayInputStream("test content".getBytes());
+
+    @BeforeEach
+    public void setup() {
+        mockClient.resetRateLimits();
+        mockClient.setCurrentTimeSupplier(System::currentTimeMillis);
+        mockClient.setCurrentDateSupplier(LocalDate::now);
+        mockClient.setMinuteLimit(5);
+        mockClient.setDailyLimit(10);
+        mockClient.setSimulateFailures(false);
+    }
+
+    @Test
+    void When_MinuteLimitReached_Expect_RateLimitExceptionAndResetAfterOneMinute() throws NotificationClientException {
+        final long baseTime = System.currentTimeMillis();
+        final AtomicLong currentTime = new AtomicLong(baseTime);
+        mockClient.setCurrentTimeSupplier(currentTime::get);
+
+        for (int i = 0; i < mockClient.getMinuteLimit(); i++) {
+            SendEmailResponse response = mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE
+            );
+            assertNotNull(response);
+            assertNotNull(response.getNotificationId());
+            assertEquals(i + 1, mockClient.getCurrentMinuteRequestCount());
+        }
+
+        NotificationClientException exception = assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE
+                )
+        );
+
+        assertEquals(429, exception.getHttpResult());
+        assertTrue(exception.getMessage().contains("Rate limit exceeded"));
+
+        currentTime.set(baseTime + 61000);
+        SendEmailResponse response = mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE
+        );
+
+        assertNotNull(response);
+        assertEquals(1, mockClient.getCurrentMinuteRequestCount());
+    }
+
+    @Test
+    void When_DailyLimitReached_Expect_RateLimitExceptionAndResetNextDay() throws NotificationClientException {
+        final LocalDate baseDate = LocalDate.now();
+        mockClient.setCurrentDateSupplier(() -> baseDate);
+
+        for (int i = 0; i < mockClient.getDailyLimit(); i++) {
+            final int currentIndex = i;
+            mockClient.setCurrentTimeSupplier(() -> System.currentTimeMillis() + currentIndex * 61000L);
+
+            SendEmailResponse response = mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE
+            );
+            assertNotNull(response);
+
+            assertEquals(i + 1, mockClient.getCurrentDailyRequestCount());
+        }
+
+        NotificationClientException exception = assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE
+                )
+        );
+
+        assertEquals(429, exception.getHttpResult());
+        assertTrue(exception.getMessage().contains("Rate limit exceeded"));
+
+        mockClient.setCurrentDateSupplier(() -> baseDate.plusDays(1));
+
+        SendEmailResponse response = mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE
+        );
+
+        assertNotNull(response);
+        assertEquals(1, mockClient.getCurrentDailyRequestCount());
+    }
+
+    @Test
+    void When_LetterMinuteLimitReached_Expect_RateLimitExceptionAndResetAfterOneMinute() throws NotificationClientException {
+        final long baseTime = System.currentTimeMillis();
+        final AtomicLong currentTime = new AtomicLong(baseTime);
+        mockClient.setCurrentTimeSupplier(currentTime::get);
+
+        for (int i = 0; i < mockClient.getMinuteLimit(); i++) {
+            LetterResponse response = mockClient.sendPrecompiledLetterWithInputStream(
+                    MOCK_REFERENCE + "-" + i,
+                    TEST_PDF
+            );
+            assertNotNull(response);
+            assertNotNull(response.getNotificationId());
+
+            assertEquals(i + 1, mockClient.getCurrentMinuteRequestCount());
+        }
+
+        NotificationClientException exception = assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendPrecompiledLetterWithInputStream(
+                        MOCK_REFERENCE + "-limit-exceeded",
+                        TEST_PDF
+                )
+        );
+
+        assertEquals(429, exception.getHttpResult());
+        assertTrue(exception.getMessage().contains("Rate limit exceeded"));
+        currentTime.set(baseTime + 61000);
+
+        LetterResponse response = mockClient.sendPrecompiledLetterWithInputStream(
+                MOCK_REFERENCE + "-after-reset",
+                TEST_PDF
+        );
+
+        assertNotNull(response);
+        assertEquals(1, mockClient.getCurrentMinuteRequestCount());
+    }
+
+    @Test
+    void When_CombinedEmailAndLetterLimitReached_Expect_RateLimitException() throws NotificationClientException {
+        final long baseTime = System.currentTimeMillis();
+        final AtomicLong currentTime = new AtomicLong(baseTime);
+        mockClient.setCurrentTimeSupplier(currentTime::get);
+        mockClient.setMinuteLimit(4);
+
+        for (int i = 0; i < mockClient.getMinuteLimit() / 2; i++) {
+            SendEmailResponse response = mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE + "-email-" + i
+            );
+            assertNotNull(response);
+        }
+
+        for (int i = 0; i < mockClient.getMinuteLimit() / 2; i++) {
+            LetterResponse response = mockClient.sendPrecompiledLetterWithInputStream(
+                    MOCK_REFERENCE + "-letter-" + i,
+                    TEST_PDF
+            );
+            assertNotNull(response);
+        }
+
+        assertEquals(mockClient.getMinuteLimit(), mockClient.getCurrentMinuteRequestCount());
+
+        assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE + "-over-limit"
+                )
+        );
+
+        assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendPrecompiledLetterWithInputStream(
+                        MOCK_REFERENCE + "-over-limit",
+                        TEST_PDF
+                )
+        );
+    }
+
+    @Test
+    void When_FailureSimulationEnabled_Expect_SimulatedServerError() throws NotificationClientException {
+        mockClient.setSimulateFailures(true);
+        mockClient.setFailureRate(1.0);
+
+        NotificationClientException exception = assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE
+                )
+        );
+
+        assertEquals(500, exception.getHttpResult());
+        assertTrue(exception.getMessage().contains("Simulated server error"));
+
+        mockClient.setSimulateFailures(false);
+
+        SendEmailResponse response = mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE
+        );
+
+        assertNotNull(response);
+    }
+
+    @Test
+    void When_NonMockReferenceUsed_Expect_RateLimitsBypass() throws NotificationClientException {
+        mockClient.setMinuteLimit(1);
+        mockClient.setDailyLimit(1);
+
+        SendEmailResponse mockResponse = mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE
+        );
+        assertNotNull(mockResponse);
+
+        assertThrows(
+                NotificationClientException.class,
+                () -> mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE
+                )
+        );
+
+        // But a real reference should bypass the mock functionality entirely
+        // This will only work if there's a real API key, but in tests it would still
+        // reach a different point in the code (the super class call) before failing
+        try {
+            mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    "regular-reference-not-mocked"
+            );
+            // If we get here, either:
+            // 1. We have a valid API key, and it worked, or
+            // 2. The mock client's super call was intercepted by another mock in the test context
+            // Either way, we bypassed our rate limit check which is what we're testing
+        } catch (Exception e) {
+            // Expected in most test environments due to invalid/missing API key
+            // We just need to verify it wasn't a rate limit exception
+            assertFalse(e.getMessage().contains("Rate limit exceeded"));
+        }
+    }
+
+    @Test
+    void When_PartialFailureRateSet_Expect_MixOfSuccessesAndFailures() {
+        mockClient.setMinuteLimit(100);
+        mockClient.setDailyLimit(100);
+
+        double[] randomValues = new double[20];
+        for (int i = 0; i < 20; i++) {
+            randomValues[i] = (i % 2 == 0) ? 0.0 : 1.0;
+        }
+
+        AtomicInteger randomIndex = new AtomicInteger(0);
+        mockClient.setRandomSupplier(() -> {
+            int index = randomIndex.getAndIncrement() % randomValues.length;
+            return randomValues[index];
+        });
+
+        mockClient.setSimulateFailures(true);
+        mockClient.setFailureRate(0.5); // Failures when random value >= 0.5
+
+        int successCount = 0;
+        int failureCount = 0;
+
+        for (int i = 0; i < 20; i++) {
+            try {
+                SendEmailResponse response = mockClient.sendEmail(
+                        TEST_TEMPLATE_ID,
+                        TEST_EMAIL,
+                        Map.of("name", "Test User"),
+                        MOCK_REFERENCE + "-" + i
+                );
+                assertNotNull(response);
+                successCount++;
+            } catch (NotificationClientException e) {
+                assertEquals(500, e.getHttpResult());
+                assertTrue(e.getMessage().contains("Simulated server error"));
+                failureCount++;
+            }
+        }
+
+        assertEquals(10, successCount, "Should have exactly 10 successful requests");
+        assertEquals(10, failureCount, "Should have exactly 10 failed requests");
+    }
+
+    @Test
+    void When_RequestsAreBelowLimit_Expect_AllSucceed() throws NotificationClientException {
+        mockClient.setMinuteLimit(5);
+
+        for (int i = 0; i < mockClient.getMinuteLimit() - 1; i++) {
+            SendEmailResponse response = mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE + "-" + i
+            );
+            assertNotNull(response);
+            assertEquals(i + 1, mockClient.getCurrentMinuteRequestCount());
+        }
+
+        assertEquals(mockClient.getMinuteLimit() - 1, mockClient.getCurrentMinuteRequestCount());
+
+        SendEmailResponse response = mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE + "-final"
+        );
+
+        assertNotNull(response);
+        assertEquals(mockClient.getMinuteLimit(), mockClient.getCurrentMinuteRequestCount());
+    }
+
+    @Test
+    void When_TimeRollsForwardPartially_Expect_OldRequestsExpireFromMinuteCounter() throws NotificationClientException {
+        final long baseTime = System.currentTimeMillis();
+        final AtomicLong currentTime = new AtomicLong(baseTime);
+        mockClient.setCurrentTimeSupplier(currentTime::get);
+        mockClient.setMinuteLimit(5);
+
+        for (int i = 0; i < 3; i++) {
+            mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE + "-initial-" + i
+            );
+        }
+
+        currentTime.set(baseTime + 30000);
+
+        assertEquals(3, mockClient.getCurrentMinuteRequestCount());
+
+        currentTime.set(baseTime + 65000);
+
+        mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE + "-after-expiry"
+        );
+
+        assertEquals(1, mockClient.getCurrentMinuteRequestCount());
+    }
+
+    @Test
+    void When_DateChanges_Expect_DailyCounterReset() throws NotificationClientException {
+        final LocalDate baseDate = LocalDate.now();
+        mockClient.setCurrentDateSupplier(() -> baseDate);
+
+        for (int i = 0; i < 3; i++) {
+            mockClient.sendEmail(
+                    TEST_TEMPLATE_ID,
+                    TEST_EMAIL,
+                    Map.of("name", "Test User"),
+                    MOCK_REFERENCE + "-day1-" + i
+            );
+        }
+
+        assertEquals(3, mockClient.getCurrentDailyRequestCount());
+
+        mockClient.setCurrentDateSupplier(() -> baseDate.plusDays(1));
+        mockClient.sendEmail(
+                TEST_TEMPLATE_ID,
+                TEST_EMAIL,
+                Map.of("name", "Test User"),
+                MOCK_REFERENCE + "-day2"
+        );
+
+        assertEquals(1, mockClient.getCurrentDailyRequestCount());
+    }
+}


### PR DESCRIPTION
Add GOV.UK Notify mock implementation for non-production environments

- Implement MockNotificationClient for local, dev, and test profiles
- Add transparent mocking with configurable rate limits and failure simulation
- Support mock toggling via reference prefix "use-mock-notify"
- Updated sendEmail method to require explicit reference parameter
- Add configuration properties for customizing mock behavior
- Include comprehensive test suite for MockNotificationClient
- Add detailed README explaining mock features and usage

This allows QA to test notification functionality without hitting real GOV.UK Notify API during development, while maintaining production behavior unchanged.

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__