### PR TITLE
DEEP-349: Welsh Transitional PSC Information letter template

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
@@ -79,17 +79,13 @@ public class TemplatePersonaliser {
         validatePersonalisationDetails(personalisationDetails);
 
         var context = new Context();
-
-        pathsPublisher.publishPathsViaContext(context, templateLookupKey);
-        welshDatesPublisher.publishWelshDatesViaContext(context, personalisationDetails);
-
         populateLetterWithTodaysDate(context, templateLookupKey);
-
         context.setVariable(REFERENCE, reference);
-
         var upperCaseCompanyName = getUpperCasedCompanyName(personalisationDetails);
         populateAddress(context, address, upperCaseCompanyName);
         personaliseLetter(context, personalisationDetails, upperCaseCompanyName);
+        pathsPublisher.publishPathsViaContext(context, templateLookupKey);
+        welshDatesPublisher.publishWelshDatesViaContext(context);
 
         validator.validateContextForTemplate(context, templateLookupKey);
 

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/WelshDatesPublisher.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/WelshDatesPublisher.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatepersonal
 
 import static java.util.AbstractMap.SimpleEntry;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.context.Context;
@@ -34,20 +35,20 @@ public class WelshDatesPublisher {
                      new SimpleEntry<>("November",  "Tachwedd"),
                      new SimpleEntry<>("December",  "Rhagfyr"));
 
-    public void publishWelshDatesViaContext(final Context context,
-                                            final Map<String, String> personalisationDetails) {
-        personalisationDetails.keySet()
-                .stream()
+    public void publishWelshDatesViaContext(final Context context) {
+        var variables = new HashMap<String, Object>();
+        context.getVariableNames().stream()
                 .filter(key -> key.endsWith(DATE_VARIABLE_NAME_SUFFIX))
-                .forEach(key -> this.publishWelshDate(context, personalisationDetails, key));
+                .forEach(key -> this.publishWelshDate(context, variables, key));
+        context.setVariables(variables);
     }
 
     private void publishWelshDate(final Context context,
-                                  final Map<String, String> personalisationDetails,
+                                  final Map<String, Object> variables,
                                   final String dateVariableName) {
         var welshDate = getWelshDate(
-                personalisationDetails.get(dateVariableName), dateVariableName);
-        context.setVariable(WELSH_DATE_VARIABLE_NAME_PREFIX + dateVariableName, welshDate);
+                (String) context.getVariable(dateVariableName), dateVariableName);
+        variables.put(WELSH_DATE_VARIABLE_NAME_PREFIX + dateVariableName, welshDate);
     }
 
     private String getWelshDate(final String englishDate, final String dateVariableName) {

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/WelshDatesPublisher.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/WelshDatesPublisher.java
@@ -51,7 +51,7 @@ public class WelshDatesPublisher {
         variables.put(WELSH_DATE_VARIABLE_NAME_PREFIX + dateVariableName, welshDate);
     }
 
-    private String getWelshDate(final String englishDate, final String dateVariableName) {
+    public static String getWelshDate(final String englishDate, final String dateVariableName) {
         var dayMonthYear = englishDate.split(" ");
         if (dayMonthYear.length != 3) {
             throw new LetterValidationException("Format of date '" + dateVariableName

--- a/src/main/resources/assets/templates/letters/chips/extension_acceptance_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/extension_acceptance_letter_content_v1.html
@@ -55,7 +55,7 @@
                 to the PSC name on our records.</p>
             <p class="verification-requirements-text">Search online for the ‘Provide identity
                 verification details for a person with significant control’ service, or visit:<br/>
-                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+                <span class="emphasis">gov.uk/provide-identity-verification-details-for-a-psc</span>
             </p>
             <p class="verification-requirements-text">You’ll also be asked to tick a statement confirming
                 that you’ve verified your identity.</p>
@@ -69,7 +69,7 @@
 <p style="margin-top: 1mm">Before <span id="idv-verification-due-date-2">[[${idv_verification_due_date}]]</span>, you can
     use the ‘Provide identity verification details for a person with significant control’ service to request
     another extension. This time, you’ll need to provide evidence to support your request:<br/>
-    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+    <span class="emphasis" style="margin-top: 1mm">gov.uk/provide-identity-verification-details-for-a-psc</span>
 </p>
 
 <p class="small-heading">Why PSCs need to verify their identity</p>

--- a/src/main/resources/assets/templates/letters/chips/new_psc_direction_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/new_psc_direction_letter_content_v1.html
@@ -54,7 +54,7 @@
                 to the PSC name on our records.</p>
             <p class="verification-requirements-text">Search online for the ‘Provide identity
                 verification details for a person with significant control’ service, or visit:<br/>
-                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+                <span class="emphasis">gov.uk/provide-identity-verification-details-for-a-psc</span>
             </p>
             <p class="verification-requirements-text">You’ll also be asked to tick a statement confirming
                 that you’ve verified your identity.</p>
@@ -67,7 +67,7 @@
 <p class="small-heading">If you are unable to complete both steps by the deadline</p>
 <p style="margin-top: 1mm">Before <span id="idv-verification-due-date-2">[[${idv_verification_due_date}]]</span>, you should use the
     ‘Provide identity verification details for a person with significant control’ service to request an extension:<br/>
-    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+    <span class="emphasis" style="margin-top: 1mm">gov.uk/provide-identity-verification-details-for-a-psc</span>
 </p>
 
 <p class="small-heading">Why PSCs need to verify their identity</p>

--- a/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_content_v1.html
@@ -54,7 +54,7 @@
                 to the PSC name on our records.</p>
             <p class="verification-requirements-text">Search online for the ‘Provide identity
                 verification details for a person with significant control’ service, or visit:<br/>
-                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+                <span class="emphasis">gov.uk/provide-identity-verification-details-for-a-psc</span>
             </p>
             <p class="verification-requirements-text">You’ll also be asked to tick a statement confirming
                 that you’ve verified your identity.</p>
@@ -68,7 +68,7 @@
 <p style="margin-top: 1mm">Between <span id="idv-start-date">[[${idv_start_date}]]</span> and
     <span id="idv-verification-due-date-2">[[${idv_verification_due_date}]]</span>, you can use the
     ‘Provide identity verification details for a person with significant control’ service to request an extension:<br/>
-    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+    <span class="emphasis" style="margin-top: 1mm">gov.uk/provide-identity-verification-details-for-a-psc</span>
 </p>
 
 <p class="small-heading">Why PSCs need to verify their identity</p>

--- a/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_v1.css
+++ b/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_v1.css
@@ -14,3 +14,19 @@
     background-color: black;
     border-radius: 1.2mm;
 }
+.welsh-transitional-non-director-psc-information-letter-title {
+    display: block;
+    height: 22mm;
+    width: 58mm; /* was 70 then 64mm */
+    font-family: Arial, sans-serif;
+    font-weight:bold;
+    font-size: 5.0mm;
+    line-height: 5.5mm;
+    color: white;
+    padding-left: 4mm;
+    padding-right: 3mm;
+    padding-bottom: 4mm;
+    padding-top: 3mm;
+    background-color: black;
+    border-radius: 1.2mm;
+}

--- a/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/transitional_non_director_psc_information_letter_v1.html
@@ -20,8 +20,8 @@
 <body>
     <div id="welsh_letter" th:if="${is_welsh}" th:with="is_welsh_letter=true">
         <section th:replace="~{../common/notify_letter_layout :: notifyLetterLayout(
-            ~{welsh_new_psc_direction_letter_content_v1},
-            ~{welsh_new_psc_direction_letter_title_v1},
+            ~{welsh_transitional_non_director_psc_information_letter_content_v1},
+            ~{welsh_transitional_non_director_psc_information_letter_title_v1},
             'Cyfeirnod',
             ${reference})}">
         </section>

--- a/src/main/resources/assets/templates/letters/chips/welsh_new_psc_direction_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_new_psc_direction_letter_content_v1.html
@@ -55,7 +55,7 @@
                 gwirio â’r enw PRhA ar ein cofnodion.</p>
             <p class="verification-requirements-text">Chwiliwch ar-lein am y gwasanaeth
                 ‘Darparu manylion gwiriad hunaniaeth ar gyfer person sydd â rheolaeth arwyddocaol, neu ewch i:<br/>
-                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+                <span class="emphasis">gov.uk/provide-identity-verification-details-for-a-psc</span>
             </p>
             <p class="verification-requirements-text">Gofynnir i chi hefyd dicio datganiad sy’n cadarnhau eich bod
                 wedi cwblhau gwiriad hunaniaeth.</p>
@@ -69,7 +69,7 @@
 <p style="margin-top: 1mm">Cyn <span id="welsh-idv-verification-due-date-2">[[${welsh_idv_verification_due_date}]]</span>, dylech
     ddefnyddio’r gwasanaeth ‘Darparu manylion gwiriad hunaniaeth ar gyfer person â rheolaeth arwyddocaol’ i ofyn
     am estyniad:<br/>
-    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+    <span class="emphasis" style="margin-top: 1mm">gov.uk/provide-identity-verification-details-for-a-psc</span>
 </p>
 
 <p class="small-heading">Pam mae angen i PRhA gwblhau gwiriad hunaniaeth</p>

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
@@ -30,57 +30,54 @@
     </table>
 </p>
 
-<p class="subject-line" style="page-break-before: always">There are 2 things you must do to comply with identity
-    verification requirements.</p>
+<p class="subject-line" style="page-break-before: always">Mae yna 2 beth y mae’n rhaid i chi eu gwneud i gydymffurfio â gofynion
+    gwiriad hunaniaeth.</p>
 <p class="subject-line-spacer"></p>
 
 <table>
     <tr>
         <td class="verification-requirements">
-            <p class="verification-requirements-heading">1. Verify your identity</p>
-            <p class="verification-requirements-text">For information on how to do this, search
-                online for ‘Verifying your identity for
-                Companies House’, or visit:<br/>
+            <p class="verification-requirements-heading">1. Cwblhau gwiriad hunaniaeth</p>
+            <p class="verification-requirements-text">I gael gwybodaeth am sut i wneud hyn, chwiliwch ar-lein am
+                ‘Gwirio eich hunaniaeth ar gyfer Tŷ’r Cwmnïau’, neu ewch i:
                 <span class="emphasis">gov.uk/guidance/verifying-your-identity-for-companies-house</span>
             </p>
-            <p class="verification-requirements-text">After you’ve verified your identity, you’ll get a
-                unique identifier, called a Companies House personal code.</p>
-            <p class="verification-requirements-text">If you already have a personal code, you do not
-                need to verify your identity again.</p>
+            <p class="verification-requirements-text">Ar ôl i chi gwblhau gwiriad hunaniaeth, mi fyddwch yn cael cod
+                adnabod unigryw, o’r enw cod personol<br/> Tŷ’r Cwmnïau.</p>
+            <p class="verification-requirements-text">Os oes gennych god personol eisoes, nid oes angen i chi
+                gwblhau gwiriad hunaniaeth eto.</p>
         </td>
         <td class="verification-requirements-spacer"></td>
         <td class="verification-requirements">
-            <p class="verification-requirements-heading">2. Provide your Companies
-                House personal code</p>
-            <p class="verification-requirements-text">This is so we can connect your verified identity
-                to the PSC name on our records.</p>
-            <p class="verification-requirements-text">Search online for the ‘Provide identity
-                verification details for a person with significant control’ service, or visit:<br/>
+            <p class="verification-requirements-heading">2. Darparu eich cod personol
+                i Dŷ’r Cwmnïau</p>
+            <p class="verification-requirements-text">Mae hyn er mwyn i ni allu cysylltu eich hunaniaeth sydd wedi’i
+                gwirio â’r enw PRhA ar ein cofnodion.</p>
+            <p class="verification-requirements-text">Chwiliwch ar-lein am y gwasanaeth
+                ‘Darparu manylion gwiriad hunaniaeth ar gyfer person sydd â rheolaeth arwyddocaol, neu ewch i:<br/>
                 <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
             </p>
-            <p class="verification-requirements-text">You’ll also be asked to tick a statement confirming
-                that you’ve verified your identity.</p>
-            <p class="verification-requirements-text">You need to do this even if you’ve already done it
-                for other roles you have at this company, or at other companies.</p>
+            <p class="verification-requirements-text">Gofynnir i chi hefyd dicio datganiad sy’n cadarnhau eich bod
+                wedi cwblhau gwiriad hunaniaeth.</p>
+            <p class="verification-requirements-text">Mae angen i chi wneud hyn hyd yn oed os ydych chi eisoes wedi
+                ei wneud ar gyfer rolau eraill sydd gennych chi yn y cwmni, neu mewn cwmnïau eraill.</p>
         </td>
     </tr>
 </table>
 
-<p class="small-heading">If you are unable to complete both steps by the deadline</p>
-<p style="margin-top: 1mm">Between <span id="idv-start-date">[[${idv_start_date}]]</span> and
-    <span id="idv-verification-due-date-2">[[${idv_verification_due_date}]]</span>, you can use the
-    ‘Provide identity verification details for a person with significant control’ service to request an extension:<br/>
+<p class="small-heading">Os na allwch gwblhau'r ddau gam erbyn y dyddiad cau</p>
+<p style="margin-top: 1mm">Rhwng <span id="idv-start-date">[[${welsh_idv_start_date}]]</span> a
+    <span id="welsh-idv-verification-due-date-2">[[${welsh_idv_verification_due_date}]]</span>, gallwch ddefnyddio'r gwasanaeth
+    'Darparu manylion gwiriad hunaniaeth ar gyfer person sydd â rheolaeth arwyddocaol' i ofyn am estyniad:<br/>
     <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
 </p>
 
-<p class="small-heading">Why PSCs need to verify their identity</p>
-<p style="margin-top: 1mm">This is a new legal requirement under the Economic Crime and Corporate Transparency
-    Act 2023.</p>
-<p style="margin-top: 1mm">All company directors and PSCs must verify their identity to prove they are who
-    they say they are.</p>
-<p style="margin-top: 1mm">This has been introduced to help prevent people using companies for illegal purposes.</p>
+<p class="small-heading">Pam mae angen i PRhA gwblhau gwiriad hunaniaeth</p>
+<p style="margin-top: 1mm">Mae hwn yn ofyniad cyfreithiol newydd o dan Ddeddf Troseddau Economaidd a Thryloywder Corfforaethol 2023.
+    Rhaid i bob cyfarwyddwr cwmni a PRhA gwblhau gwiriad hunaniaeth i brofi mai nhw yw pwy maen nhw’n honni eu bod nhw.
+    Mae hyn wedi’i gyflwyno i helpu i atal pobl rhag defnyddio cwmnïau at ddibenion anghyfreithlon.</p>
 
-<p class="small-heading">If you’re no longer a PSC of this company</p>
-<p style="margin-top: 1mm">You should contact the company and let them know they need to update the PSC information on the Companies
-    House register. If you’ve already done this, and the company has notified us of those changes,
-    you do not need to do anything else.</p>
+<p class="small-heading">Os nad ydych bellach yn PRhA o'r cwmni hwn</p>
+<p style="margin-top: 1mm">Dylech gysylltu â'r cwmni a rhoi gwybod iddynt fod angen iddynt ddiweddaru'r wybodaeth
+    PRhA ar gofrestr Tŷ'r Cwmnïau. Os ydych chi eisoes wedi gwneud hyn, ac mae'r cwmni wedi ein hysbysu o'r
+    newidiadau hynny, nid oes angen i chi wneud unrhyw beth arall.</p>

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
@@ -55,7 +55,7 @@
                 gwirio â’r enw PRhA ar ein cofnodion.</p>
             <p class="verification-requirements-text">Chwiliwch ar-lein am y gwasanaeth
                 ‘Darparu manylion gwiriad hunaniaeth ar gyfer person sydd â rheolaeth arwyddocaol, neu ewch i:<br/>
-                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+                <span class="emphasis">gov.uk/provide-identity-verification-details-for-a-psc</span>
             </p>
             <p class="verification-requirements-text">Gofynnir i chi hefyd dicio datganiad sy’n cadarnhau eich bod
                 wedi cwblhau gwiriad hunaniaeth.</p>
@@ -69,7 +69,7 @@
 <p style="margin-top: 1mm">Rhwng <span id="idv-start-date">[[${welsh_idv_start_date}]]</span> a
     <span id="welsh-idv-verification-due-date-2">[[${welsh_idv_verification_due_date}]]</span>, gallwch ddefnyddio'r gwasanaeth
     'Darparu manylion gwiriad hunaniaeth ar gyfer person sydd â rheolaeth arwyddocaol' i ofyn am estyniad:<br/>
-    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+    <span class="emphasis" style="margin-top: 1mm">gov.uk/provide-identity-verification-details-for-a-psc</span>
 </p>
 
 <p class="small-heading">Pam mae angen i PRhA gwblhau gwiriad hunaniaeth</p>

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
@@ -1,0 +1,84 @@
+<p class="subject-line">You need to verify your identity for Companies House.</p>
+<p class="subject-line">This is for your role as a person with significant control of:</p>
+<p class="subject-line"><span class="subject-line">[[${company_name}]] ([[${company_number}]])</span></p>
+<hr/>
+
+<p class="close-packed-top">Dear <span class="emphasis">[[${psc_name}]]</span></p>
+<p class="close-packed-middle">As a person with significant control (PSC) of a UK company, there’s a new
+    legal requirement for you to verify your identity for Companies House, and to deliver a statement
+    confirming that you have done so.</p>
+<p>As a PSC who is not also a director of this company, you must provide your statement within the first 14
+    days of your birth month. Based on the data we hold, you’ll need to do this between:<br/>
+    <span class="emphasis">[[${idv_start_date}]] – [[${idv_verification_due_date}]]</span></p>
+<p>Instructions on how to meet these identity verification requirements are on the back of this letter.</p>
+<p class="emphatic-block">You must comply with identity verification requirements by
+    <span class="emphasis" id="idv-verification-due-date">[[${idv_verification_due_date}]]</span>.</p>
+<p class="warning-block">
+    If you do not comply, you may be committing an offence. You may face<br/>
+    prosecution and a fine through the courts, or a financial penalty. In the future,<br/>
+    we’ll publish a note against your name on the Companies House public register.
+    <img class="warning-img" th:src="@{${common} + warning.svg}" alt="Companies House warning"/>
+</p>
+
+<p class="emphasis" style="margin-top: 8mm">
+    <img class="information-img" th:src="@{${common} + information.svg}" alt="Companies House information"/>
+    <table style="width: 100%; margin-left: 8mm">
+        <tr></tr>
+        <tr>If you are not [[${psc_name}]], you must forward this letter to them immediately.</tr>
+    </table>
+</p>
+
+<p class="subject-line" style="page-break-before: always">There are 2 things you must do to comply with identity
+    verification requirements.</p>
+<p class="subject-line-spacer"></p>
+
+<table>
+    <tr>
+        <td class="verification-requirements">
+            <p class="verification-requirements-heading">1. Verify your identity</p>
+            <p class="verification-requirements-text">For information on how to do this, search
+                online for ‘Verifying your identity for
+                Companies House’, or visit:<br/>
+                <span class="emphasis">gov.uk/guidance/verifying-your-identity-for-companies-house</span>
+            </p>
+            <p class="verification-requirements-text">After you’ve verified your identity, you’ll get a
+                unique identifier, called a Companies House personal code.</p>
+            <p class="verification-requirements-text">If you already have a personal code, you do not
+                need to verify your identity again.</p>
+        </td>
+        <td class="verification-requirements-spacer"></td>
+        <td class="verification-requirements">
+            <p class="verification-requirements-heading">2. Provide your Companies
+                House personal code</p>
+            <p class="verification-requirements-text">This is so we can connect your verified identity
+                to the PSC name on our records.</p>
+            <p class="verification-requirements-text">Search online for the ‘Provide identity
+                verification details for a person with significant control’ service, or visit:<br/>
+                <span class="emphasis">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+            </p>
+            <p class="verification-requirements-text">You’ll also be asked to tick a statement confirming
+                that you’ve verified your identity.</p>
+            <p class="verification-requirements-text">You need to do this even if you’ve already done it
+                for other roles you have at this company, or at other companies.</p>
+        </td>
+    </tr>
+</table>
+
+<p class="small-heading">If you are unable to complete both steps by the deadline</p>
+<p style="margin-top: 1mm">Between <span id="idv-start-date">[[${idv_start_date}]]</span> and
+    <span id="idv-verification-due-date-2">[[${idv_verification_due_date}]]</span>, you can use the
+    ‘Provide identity verification details for a person with significant control’ service to request an extension:<br/>
+    <span class="emphasis" style="margin-top: 1mm">provide-identity-verification-details-for-a-psc.service.gov.uk</span>
+</p>
+
+<p class="small-heading">Why PSCs need to verify their identity</p>
+<p style="margin-top: 1mm">This is a new legal requirement under the Economic Crime and Corporate Transparency
+    Act 2023.</p>
+<p style="margin-top: 1mm">All company directors and PSCs must verify their identity to prove they are who
+    they say they are.</p>
+<p style="margin-top: 1mm">This has been introduced to help prevent people using companies for illegal purposes.</p>
+
+<p class="small-heading">If you’re no longer a PSC of this company</p>
+<p style="margin-top: 1mm">You should contact the company and let them know they need to update the PSC information on the Companies
+    House register. If you’ve already done this, and the company has notified us of those changes,
+    you do not need to do anything else.</p>

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_content_v1.html
@@ -1,30 +1,32 @@
-<p class="subject-line">You need to verify your identity for Companies House.</p>
-<p class="subject-line">This is for your role as a person with significant control of:</p>
+<p class="subject-line">Mae angen i chi gwblhau gwiriad hunaniaeth ar gyfer Tŷ'r Cwmnïau.</p>
+<p class="subject-line">Mae hyn ar gyfer eich rôl fel person sydd â rheolaeth arwyddocaol o:</p>
 <p class="subject-line"><span class="subject-line">[[${company_name}]] ([[${company_number}]])</span></p>
 <hr/>
 
-<p class="close-packed-top">Dear <span class="emphasis">[[${psc_name}]]</span></p>
-<p class="close-packed-middle">As a person with significant control (PSC) of a UK company, there’s a new
-    legal requirement for you to verify your identity for Companies House, and to deliver a statement
-    confirming that you have done so.</p>
-<p>As a PSC who is not also a director of this company, you must provide your statement within the first 14
-    days of your birth month. Based on the data we hold, you’ll need to do this between:<br/>
-    <span class="emphasis">[[${idv_start_date}]] – [[${idv_verification_due_date}]]</span></p>
-<p>Instructions on how to meet these identity verification requirements are on the back of this letter.</p>
-<p class="emphatic-block">You must comply with identity verification requirements by
-    <span class="emphasis" id="idv-verification-due-date">[[${idv_verification_due_date}]]</span>.</p>
+<p class="close-packed-top">Annwyl <span class="emphasis">[[${psc_name}]]</span></p>
+<p class="close-packed-middle">Fel person sydd â rheolaeth arwyddocaol (PRhA) o gwmni yn y DU,
+    mae gofyniad cyfreithiol newydd i chi gwblhau gwiriad hunaniaeth ar gyfer Tŷ'r Cwmnïau,
+    ac i gyflwyno datganiad yn cadarnhau eich bod wedi gwneud hynny.</p>
+<p>Fel PRhA nad yw hefyd yn gyfarwyddwr y cwmni hwn, mae’n rhaid i chi ddarparu eich datganiad
+    o fewn 14 diwrnod cyntaf eich mis geni. Yn seiliedig ar y data sydd gennym, bydd angen i
+    chi wneud hyn rhwng:<br/>
+    <span class="emphasis">[[${welsh_idv_start_date}]] – [[${welsh_idv_verification_due_date}]]</span></p>
+<p>Mae cyfarwyddiadau ar sut i gwrdd â gofynion gwiriad hunaniaeth hyn ar gefn y llythyr hwn.</p>
+<p class="emphatic-block">Mae’n rhaid i chi gydymffurfio â gofynion gwiriad hunaniaeth erbyn
+    <span class="emphasis" id="idv-verification-due-date">[[${welsh_idv_verification_due_date}]]</span>.</p>
 <p class="warning-block">
-    If you do not comply, you may be committing an offence. You may face<br/>
-    prosecution and a fine through the courts, or a financial penalty. In the future,<br/>
-    we’ll publish a note against your name on the Companies House public register.
-    <img class="warning-img" th:src="@{${common} + warning.svg}" alt="Companies House warning"/>
+    Os nad ydych chi’n cydymffurfio, efallai y byddwch chi’n cyflawni trosedd.<br/>
+    Efallai y byddwch yn wynebu erlyniad a dirwy drwy’r llysoedd, neu gosb<br/>
+    ariannol. Yn y dyfodol, byddwn yn cyhoeddi nodyn yn erbyn eich enw ar gofrestr<br/>
+    gyhoeddus Tŷ’r Cwmnïau.
+    <img class="welsh-warning-img" th:src="@{${common} + warning.svg}" alt="Companies House warning"/>
 </p>
 
 <p class="emphasis" style="margin-top: 8mm">
     <img class="information-img" th:src="@{${common} + information.svg}" alt="Companies House information"/>
     <table style="width: 100%; margin-left: 8mm">
         <tr></tr>
-        <tr>If you are not [[${psc_name}]], you must forward this letter to them immediately.</tr>
+        <tr>Os nad chi yw [[${psc_name}]], mae’n rhaid i chi anfon y llythyr ymlaen atynt ar unwaith.</tr>
     </table>
 </p>
 

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_title_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_title_v1.html
@@ -1,3 +1,2 @@
-<span class="transitional-non-director-psc-information-letter-title">Verify your identity<br/>
-—person with
-significant control</span>
+<span class="welsh-transitional-non-director-psc-information-letter-title">Cwblhau gwiriad hunaniaeth<br/>
+    –Person sydd â rheolaeth arwyddocaol</span>

--- a/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_title_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_transitional_non_director_psc_information_letter_title_v1.html
@@ -1,0 +1,3 @@
+<span class="transitional-non-director-psc-information-letter-title">Verify your identity<br/>
+—person with
+significant control</span>

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/LetterSavingSenderRestApiIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/restapi/LetterSavingSenderRestApiIntegrationTest.java
@@ -113,6 +113,12 @@ class LetterSavingSenderRestApiIntegrationTest extends AbstractMongoDBTest {
     }
 
     @Test
+    @DisplayName("Send Welsh Transitional Non-director PSC Information letter successfully, saving letter PDF for troubleshooting in the process")
+    void sendWelshTransitionalPscInformationLetterSuccessfully(CapturedOutput log) throws Exception {
+        sendWelshLetter("send-transitional-non-director-psc-information-letter-request", log);
+    }
+
+    @Test
     @DisplayName("Send Extension Acceptance letter successfully, saving letter PDF for troubleshooting in the process")
     void sendExtensionAcceptanceLetterSuccessfully(CapturedOutput log) throws Exception {
         sendLetter("send-extension-acceptance-letter-request", log);

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
@@ -26,6 +26,7 @@ import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelo
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_EXTENSION_ACCEPTANCE_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_NEW_PSC_DIRECTION_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_TRANSITIONAL_NON_DIRECTOR_PSC_INFORMATION_LETTER_1;
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatepersonalisation.WelshDatesPublisher.getWelshDate;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -75,9 +76,11 @@ class TemplatePersonaliserIntegrationTest {
     private static final String VALID_IDV_VERIFICATION_DUE_DATE = "14 July 2025";
     private static final String VALID_EXTENSION_REQUEST_DATE = "13 July 2025";
     private static final String TODAYS_DATE;
+    private static final String TODAYS_DATE_IN_WELSH;
     static {
         var format = DateTimeFormatter.ofPattern("dd MMMM yyyy");
         TODAYS_DATE = LocalDate.now().format(format);
+        TODAYS_DATE_IN_WELSH = getWelshDate(TODAYS_DATE, "today's date");
     }
 
     private static final String EXPECTED_WELSH_PSC_APPOINTMENT_DATE = "24 Mehefin 2025";
@@ -281,6 +284,29 @@ class TemplatePersonaliserIntegrationTest {
     }
 
     @Test
+    @DisplayName("Generate Welsh Transitional Non-director PSC Information Letter HTML successfully")
+    void generateWelshTransitionalPscLetterHtmlSuccessfully() {
+
+        // Given and when
+        var letter = parse(templatePersonalisation.personaliseLetterTemplate(
+                CHIPS_TRANSITIONAL_NON_DIRECTOR_PSC_INFORMATION_LETTER_1,
+                "Welsh Transitional Non-director PSC Information Letter",
+                Map.of(IDV_VERIFICATION_DUE_DATE, VALID_IDV_VERIFICATION_DUE_DATE,
+                        LETTER_SENDING_DATE, TODAYS_DATE,
+                        IDV_START_DATE, VALID_IDV_START_DATE,
+                        COMPANY_NUMBER, TOKEN_VALUE,
+                        COMPANY_NAME, TOKEN_VALUE,
+                        PSC_NAME, TOKEN_VALUE,
+                        IS_WELSH, "true"),
+                ADDRESS));
+
+        // Then
+        verifyLetterIsBilingualEnglishAndWelsh(letter);
+        verifyLetterDateIsTodaysDate(letter);
+        verifyWelshLetterDateIsTodaysDate(letter);
+    }
+
+    @Test
     @DisplayName("Generate English Extension Acceptance Letter HTML successfully")
     void generateEnglishExtensionAcceptanceLetterHtmlSuccessfully() {
 
@@ -345,6 +371,10 @@ class TemplatePersonaliserIntegrationTest {
 
     private static void verifyLetterDateIsTodaysDate(final Document letter) {
         assertThat(getText(letter, "#letter-date"), is(TODAYS_DATE));
+    }
+
+    private static void verifyWelshLetterDateIsTodaysDate(final Document letter) {
+        assertThat(getText(letter, "#welsh-letter-date"), is(TODAYS_DATE_IN_WELSH));
     }
 
     private static void verifyLetterDateIsIdvStartDate(final Document letter) {

--- a/src/test/postman/chs-gov-uk-notify-integration-api.postman_collection.json
+++ b/src/test/postman/chs-gov-uk-notify-integration-api.postman_collection.json
@@ -238,6 +238,44 @@
 					"response": []
 				},
 				{
+					"name": "send Welsh Transitional Non-director PSC Information Letter",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "X-Request-ID",
+								"value": "X9uND6rXQxfbZNcMVFA7JI4h2KOh",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"sender_details\": {\n        \"app_id\": \"chips\",\n        \"reference\": \"Welsh Transitional Non-director PSC Information Letter\",\n        \"name\": \"name\",\n        \"user_id\": \"user_id\",\n        \"email_address\": \"jbloggs@jbloggs.com\"\n    },\n    \"recipient_details\": {\n        \"name\": \"Joe Bloggs\",\n        \"physical_address\": {\n            \"address_line_1\": \"Joe Bloggs\",\n            \"address_line_2\": \"Some Company\",\n            \"address_line_3\": \"Ffordd y Goron\",\n            \"address_line_4\": \"Caerdydd\",\n            \"address_line_5\": \"CF14 3UZ\",\n            \"address_line_6\": \"United Kingdom\"\n        } \n    },\n    \"letter_details\": {\n        \"template_id\": \"transitional_non_director_psc_information_letter\",\n        \"template_version\": 1,\n        \"personalisation_details\": \"{ \\\"idv_start_date\\\": \\\"9 July 2025\\\", \\\"idv_verification_due_date\\\": \\\"23 July 2025\\\", \\\"psc_name\\\": \\\"Joe Bloggs\\\", \\\"company_name\\\": \\\"Some Company\\\", \\\"company_number\\\": \\\"00006400\\\", \\\"is_welsh\\\": true }\"\n    },\n    \"created_at\": \"2025-05-09T09:02:24.905+05:30\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/gov-uk-notify-integration/letter",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"gov-uk-notify-integration",
+								"letter"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "send Extension Acceptance Letter",
 					"request": {
 						"method": "POST",


### PR DESCRIPTION
__DEEP-349__

* __Add template and tests for bilingual Welsh English version of the Transitional Non-director PSC Information letter.__
* __Correct Welsh date publication logic to ensure the letter sending date is rendered in Welsh in the Welsh part of the letter.__
* __Fill out Welsh content as per design.__
* __Update PSC IDV URL used in ALL "real" letters.__

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__