### PR TITLE
DEEP-444: Upgrade to grpc-context 1.60.2 to avoid CVE-2024-7246

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <spring-context.version>6.2.8</spring-context.version>
         <spring-web.version>6.2.8</spring-web.version>
         <tomcat-embed.version>10.1.42</tomcat-embed.version>
+        <grpc-context.version>1.60.2</grpc-context.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>
@@ -264,6 +265,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-context</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -327,6 +332,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+            <version>${grpc-context.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
__DEEP-444 WIP__

* __Upgrade to `grpc-context` `1.60.2` to avoid CVE-2024-7246.__
* __Compare `dependency-check` [before](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/chs-gov-uk-notify-integration-api/jobs/dependency-check/builds/115) and [after](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/chs-gov-uk-notify-integration-api/jobs/dependency-check/builds/116) this change.__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__