### PR TITLE
DEEP-444: Upgrade grpc-context to latest 1.73.0 to avoid CVE-2024-11407

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
         <spring-context.version>6.2.8</spring-context.version>
         <spring-web.version>6.2.8</spring-web.version>
         <tomcat-embed.version>10.1.42</tomcat-embed.version>
-        <grpc-context.version>1.60.2</grpc-context.version>
+        <!-- CVE-2024-11407 -->
+        <grpc-context.version>1.73.0</grpc-context.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>


### PR DESCRIPTION
__DEEP-444 WIP__

* __Upgrade to `grpc-context` to `1.73.0` to avoid CVE-2024-11407.__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__