### PR TITLE
DEEP-444: Upgrade gson to latest 2.13.1 to avoid CVE-2025-53864

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
         <tomcat-embed.version>10.1.42</tomcat-embed.version>
         <!-- CVE-2024-11407 -->
         <grpc-context.version>1.73.0</grpc-context.version>
+        <!-- CVE-2025-53864 -->
+        <gson.version>2.13.1</gson.version>
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
         <sonar.password></sonar.password>
@@ -338,6 +340,11 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-context</artifactId>
             <version>${grpc-context.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
__DEEP-444 WIP__

* __Upgrade `gson` to `2.13.1` to avoid CVE-2025-53864.__
* __Compare `dependency-check` [before](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/chs-gov-uk-notify-integration-api/jobs/dependency-check/builds/118) and [after](https://ci-platform.companieshouse.gov.uk/teams/team-development/pipelines/chs-gov-uk-notify-integration-api/jobs/dependency-check/builds/119) this change.__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__