### PR TITLE
DEEP-422: Correct typo "wneath" in Welsh New PSC Direction letter

### DIFF
--- a/src/main/resources/assets/templates/letters/chips/welsh_new_psc_direction_letter_content_v1.html
+++ b/src/main/resources/assets/templates/letters/chips/welsh_new_psc_direction_letter_content_v1.html
@@ -5,7 +5,7 @@
 
 <p class="close-packed-top">Annwyl <span class="emphasis">[[${psc_name}]]</span></p>
 <p class="close-packed-middle">Ar <span id="welsh-psc-appointment-date">[[${welsh_psc_appointment_date}]]</span>,
-    wneath [[${company_name}]] ein hysbysu eich bod yn berson â rheolaeth arwyddocaol (PRhA) o’r cwmni. Mae PRhA yn
+    wnaeth [[${company_name}]] ein hysbysu eich bod yn berson â rheolaeth arwyddocaol (PRhA) o’r cwmni. Mae PRhA yn
     rhywun sydd â rhywfaint o berchnogaeth neu reolaeth o’r cwmni, er enghraifft oherwydd bod ganddynt fwy na 25% o
     gyfrannau neu hawliau pleidleisio.</p>
 <p>O dan y pŵer a ddarperir gan adran 790LM o Ddeddf Cwmnïau 2006, mae’r Cofrestrydd Cwmnïau


### PR DESCRIPTION
__DEEP-422__

__Correct misspelt word in the 1st paragraph of the letter from `wneath` to `wnaeth`.__

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

<img width="1858" height="1291" alt="Screenshot 2025-07-28 at 11 35 20" src="https://github.com/user-attachments/assets/d99ee999-8176-40ad-aaa4-771e08aee984" />
