### PR TITLE
Add strip trailing zeros in the template version for sentletterfetcher

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/sentletterfetcher/SentLetterFetcher.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/sentletterfetcher/SentLetterFetcher.java
@@ -68,7 +68,8 @@ public class SentLetterFetcher {
         var letter = letters.getFirst().getRequest();
         var appId = letter.getSenderDetails().getAppId();
         var templateId = letter.getLetterDetails().getTemplateId();
-        var templateVersion = letter.getLetterDetails().getTemplateVersion();
+        // Ensure versions "1" and "1.0" are treated as being the same.
+        var templateVersion = letter.getLetterDetails().getTemplateVersion().stripTrailingZeros();
         var personalisationDetailsString = letter.getLetterDetails().getPersonalisationDetails();
         var personalisationDetails =
                 parser.parsePersonalisationDetails(personalisationDetailsString, contextId);
@@ -119,7 +120,8 @@ public class SentLetterFetcher {
         var letter = fetchLetterFromDatabase(pscName, companyNumber, templateId, letterSendingDate);
         var reference = letter.getSenderDetails().getReference();
         var appId = letter.getSenderDetails().getAppId();
-        var templateVersion = letter.getLetterDetails().getTemplateVersion();
+        // Ensure versions "1" and "1.0" are treated as being the same.
+        var templateVersion = letter.getLetterDetails().getTemplateVersion().stripTrailingZeros();
         var personalisationDetailsString = letter.getLetterDetails().getPersonalisationDetails();
         var personalisationDetails =
                 parser.parsePersonalisationDetails(personalisationDetailsString, contextId);


### PR DESCRIPTION
Add strip trailing zeros in the template version for sentletterfetcher so that 1 and 1.0 are treated in the same way. 

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__