### PR TITLE
Use valid contexts instead of another collection

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
@@ -17,10 +17,8 @@ import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.REFERENCE;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.TODAYS_DATE;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.TRIGGERING_EVENT_DATE;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_DIRECTION_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_EXTENSION_ACCEPTANCE_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_NEW_PSC_DIRECTION_LETTER_1;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_TRANSITIONAL_NON_DIRECTOR_PSC_INFORMATION_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CSIDVDEFLET;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.IDVPSCDEFAULT;
 
@@ -39,16 +37,6 @@ import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.validation.Templa
 
 @Component
 public class TemplatePersonaliser {
-
-    /**
-     * Those letter types for which the letter date is today's date.
-     */
-    private static final List<LetterTemplateKey> LETTERS_WITH_TODAYS_DATE =
-            List.of(CHIPS_DIRECTION_LETTER_1,
-                    CHIPS_TRANSITIONAL_NON_DIRECTOR_PSC_INFORMATION_LETTER_1,
-                    CSIDVDEFLET,
-                    IDVPSCDEFAULT);
-
     private final ITemplateEngine templateEngine;
     private final TemplateLookup templateLookup;
     private final AbstractConfigurableTemplateResolver templateResolver;
@@ -182,7 +170,7 @@ public class TemplatePersonaliser {
     private void populateLetterWithDynamicDates(Context context,
                                               Map<String, String> personalisationDetails,
                                               LetterTemplateKey templateLookupKey) {
-        if (LETTERS_WITH_TODAYS_DATE.contains(templateLookupKey)) {
+        if (validator.requiresTodaysDate(templateLookupKey)) {
             String date;
             if (personalisationDetails.containsKey(ORIGINAL_SENDING_DATE)) {
                 // Then we are regenerating a previously sent letter. Use its sending date.

--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/validation/TemplateContextValidator.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/validation/TemplateContextValidator.java
@@ -28,6 +28,7 @@ import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelo
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Component;
@@ -38,8 +39,6 @@ import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.Le
 @Component
 public class TemplateContextValidator {
 
-    // ImmutableSet preserves ordering of set elements, java.util.Set does not.
-    @SuppressWarnings("java:S4738")
     private static final Map<LetterTemplateKey, Set<String>> VALID_CONTEXTS =
             Map.ofEntries(
                     new AbstractMap.SimpleEntry<>(
@@ -139,6 +138,16 @@ public class TemplateContextValidator {
             throw new LetterValidationException("Context variable(s) "
                     + missingVariables + " missing for " + template + ".");
         }
+    }
+
+    /**
+     * Checks if the template requires today's date to be present in the context.
+     * 
+     * @param template the letter template
+     * @return True if the letter template requires today's date, false otherwise
+     */
+    public boolean requiresTodaysDate(LetterTemplateKey template) {
+        return VALID_CONTEXTS.getOrDefault(template, Collections.emptySet()).contains(TODAYS_DATE);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
@@ -359,7 +359,7 @@ class TemplatePersonaliserIntegrationTest {
         // Given and when
         var letter = parse(templatePersonalisation.personaliseLetterTemplate(
                 CSIDVDEFLET,
-                "CSIDVDEFLET_1234_5678",
+                "123456789",
                 Map.of(
                         CS_REVIEW_PERIOD_END_DATE, VALID_IDV_VERIFICATION_DUE_DATE,
                         CS_REVIEW_PERIOD_START_DATE, VALID_IDV_START_DATE,

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/validation/TemplateContextValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/validation/TemplateContextValidatorTest.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.Le
 import static java.math.BigDecimal.TWO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ADDRESS_LINE_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ADDRESS_LINE_2;
@@ -25,6 +26,7 @@ import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.REFERENCE;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_APPLICATION_ID;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_DIRECTION_LETTER_1;
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.CHIPS_EXTENSION_ACCEPTANCE_LETTER_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey.DIRECTION_LETTER;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,7 +49,6 @@ class TemplateContextValidatorTest {
     @InjectMocks
     private TemplateContextValidator validator;
 
-    @SuppressWarnings("squid:S2699") // at least one assertion`
     @Test
     @DisplayName("Does not raise an error where all required context variables are present")
     void noErrorWhereAllRequiredVariablesPresent() {
@@ -66,6 +67,8 @@ class TemplateContextValidatorTest {
 
         // When
         validator.validateContextForTemplate(context, CHIPS_DIRECTION_LETTER_1);
+
+        assertTrue(true); // no exception means success
     }
 
     @Test
@@ -118,4 +121,21 @@ class TemplateContextValidatorTest {
                 is(ALL_VARIABLES_ARE_MISSING_ERROR_MESSAGE));
     }
 
+    @Test
+    @DisplayName("requiresTodaysDate returns true for letter templates that need today's date")
+    void requiresTodaysDateIsTrue() {
+        assertThat(validator.requiresTodaysDate(CHIPS_DIRECTION_LETTER_1), is(true));
+    }
+
+    @Test
+    @DisplayName("requiresTodaysDate returns false for letter templates that do not need today's date")
+    void requiresTodaysDateIsFalse() {
+        assertThat(validator.requiresTodaysDate(CHIPS_EXTENSION_ACCEPTANCE_LETTER_1), is(false));
+    }
+
+    @Test
+    @DisplayName("requiresTodaysDate returns false for non-configured letter templates")
+    void requiresTodaysDateIsFalseForUnknownLetter() {
+        assertThat(validator.requiresTodaysDate(new LetterTemplateKey(CHIPS_APPLICATION_ID, "Unknown_v0", null)), is(false));
+    }
 }


### PR DESCRIPTION
Instead of keeping a list of letters requiring the population of today's date, we can use the `TemplateContextValidator` and check if today's date is one of the defined mandatory variables for that letter