### PR TITLE
DEEP-595: Prevent NullPointerException

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
+++ b/src/main/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliser.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatepersonalisation;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ACTION_DUE_DATE;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.Constants.DATE_FORMATTER;
+import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ACTION_DUE_DATE;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ADDRESS_LINE_1;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ADDRESS_LINE_2;
 import static uk.gov.companieshouse.chs.gov.uk.notify.integration.api.constants.ContextVariables.ADDRESS_LINE_3;
@@ -83,10 +83,11 @@ public class TemplatePersonaliser {
         var upperCaseCompanyName = getUpperCasedCompanyName(personalisationDetails);
         populateAddress(context, address, upperCaseCompanyName);
         personaliseLetter(context, personalisationDetails, upperCaseCompanyName);
-        pathsPublisher.publishPathsViaContext(context, templateLookupKey);
-        welshDatesPublisher.publishWelshDatesViaContext(context);
 
         validator.validateContextForTemplate(context, templateLookupKey);
+
+        pathsPublisher.publishPathsViaContext(context, templateLookupKey);
+        welshDatesPublisher.publishWelshDatesViaContext(context);
 
         var templateSpec = templateLookup.lookupTemplate(templateLookupKey);
         templateResolver.setPrefix(templateSpec.prefix());

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
@@ -320,15 +320,17 @@ class TemplatePersonaliserIntegrationTest {
     {
 
         // Given and when
+        var personalisationDetails = Map.of(IDV_VERIFICATION_DUE_DATE,
+                VALID_IDV_VERIFICATION_DUE_DATE,
+                COMPANY_NUMBER, TOKEN_VALUE,
+                COMPANY_NAME, TOKEN_VALUE,
+                PSC_NAME, TOKEN_VALUE);
         var validationError = assertThrows(LetterValidationException.class,
-                () -> parse(templatePersonalisation.personaliseLetterTemplate(
-                CHIPS_EXTENSION_ACCEPTANCE_LETTER_1,
-                "English Extension Acceptance Letter",
-                Map.of(IDV_VERIFICATION_DUE_DATE, VALID_IDV_VERIFICATION_DUE_DATE,
-                        COMPANY_NUMBER, TOKEN_VALUE,
-                        COMPANY_NAME, TOKEN_VALUE,
-                        PSC_NAME, TOKEN_VALUE),
-                ADDRESS)));
+                () -> templatePersonalisation.personaliseLetterTemplate(
+                        CHIPS_EXTENSION_ACCEPTANCE_LETTER_1,
+                        "English Extension Acceptance Letter",
+                        personalisationDetails,
+                        ADDRESS));
 
         assertThat(validationError.getMessage(), is(EXPECTED_VALIDATION_ERROR_MESSAGE));
     }

--- a/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/gov/uk/notify/integration/api/templatepersonalisation/TemplatePersonaliserIntegrationTest.java
@@ -1,12 +1,11 @@
 package uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatepersonalisation;
 
-import static java.math.BigDecimal.ONE;
-import static java.math.BigDecimal.TWO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -46,6 +45,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.thymeleaf.context.Context;
 import uk.gov.companieshouse.api.chs.notification.model.Address;
+import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.exception.LetterValidationException;
 import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.LetterTemplateKey;
 import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.templatelookup.TemplateLookup;
 import uk.gov.companieshouse.chs.gov.uk.notify.integration.api.validation.TemplateContextValidator;
@@ -103,6 +103,10 @@ class TemplatePersonaliserIntegrationTest {
             "pages_2_onwards_footer_artwork.svg";
     private static final String EXPECTED_WELSH_P2_FOOTER_NAME =
             "welsh_pages_2_onwards_footer_artwork.svg";
+
+    private static final String EXPECTED_VALIDATION_ERROR_MESSAGE =
+            "Context variable(s) [extension_request_date] missing for LetterTemplateKey"
+                    + "[appId=chips, id=extension_acceptance_letter_v1].";
 
     @Autowired
     private TemplatePersonaliser templatePersonalisation;
@@ -308,6 +312,25 @@ class TemplatePersonaliserIntegrationTest {
         // Then
         verifyLetterIsEnglishOnly(letter);
         verifyLetterDateIsExtensionRequestDate(letter);
+    }
+
+    @Test
+    @DisplayName("Generate English Extension Acceptance Letter HTML with missing extension_request_date fails correctly")
+    void generateEnglishExtensionAcceptanceLetterHtmlWithMissingExtensionRequestDateFailsCorrectly()
+    {
+
+        // Given and when
+        var validationError = assertThrows(LetterValidationException.class,
+                () -> parse(templatePersonalisation.personaliseLetterTemplate(
+                CHIPS_EXTENSION_ACCEPTANCE_LETTER_1,
+                "English Extension Acceptance Letter",
+                Map.of(IDV_VERIFICATION_DUE_DATE, VALID_IDV_VERIFICATION_DUE_DATE,
+                        COMPANY_NUMBER, TOKEN_VALUE,
+                        COMPANY_NAME, TOKEN_VALUE,
+                        PSC_NAME, TOKEN_VALUE),
+                ADDRESS)));
+
+        assertThat(validationError.getMessage(), is(EXPECTED_VALIDATION_ERROR_MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
__DEEP-595__

__Prevent `NullPointerException` by moving up required fields validation to take place before executing code that tries to use those required fields.__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__